### PR TITLE
Add Deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 CCXT-style unified API for prediction markets. Simple, scalable, and easy to extend.
 
+[![](https://deepwiki.com/badge.svg)](https://deepwiki.com/guzus/dr-manhattan)
 
 <p align="center">
   <img src="assets/polymarket.png" alt="Polymarket" width="50"/>


### PR DESCRIPTION
Adds Deepwiki badge to README.md as requested in issue #33.

The badge is placed after the project title and description, providing quick access to the project's Deepwiki documentation.

Fixes #33

----
Generated with [Claude Code](https://claude.ai/code)