### PR TITLE
Add landing page and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,765 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dr-manhattan | Unified API for Prediction Markets</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --void: #050508;
+            --deep-space: #0a0a10;
+            --nebula: #0d0d15;
+            --manhattan-blue: #00b4ff;
+            --manhattan-glow: #00d4ff;
+            --quantum-cyan: #00ffff;
+            --atomic-purple: #7b5cff;
+            --text-primary: #e8eaed;
+            --text-secondary: #8b9098;
+            --text-muted: #5a5f6a;
+            --code-bg: #0c0c14;
+            --border-subtle: rgba(0, 180, 255, 0.15);
+            --glow-intense: 0 0 60px rgba(0, 180, 255, 0.4), 0 0 120px rgba(0, 180, 255, 0.2);
+            --glow-soft: 0 0 30px rgba(0, 180, 255, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+        }
+
+        body {
+            font-family: 'Space Grotesk', -apple-system, sans-serif;
+            background: var(--void);
+            color: var(--text-primary);
+            line-height: 1.6;
+            overflow-x: hidden;
+        }
+
+        /* Cosmic Background */
+        .cosmic-bg {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            z-index: -1;
+            background:
+                radial-gradient(ellipse at 20% 20%, rgba(0, 180, 255, 0.08) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 80%, rgba(123, 92, 255, 0.05) 0%, transparent 50%),
+                radial-gradient(ellipse at 50% 50%, rgba(0, 212, 255, 0.03) 0%, transparent 70%);
+        }
+
+        .grid-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            z-index: -1;
+            background-image:
+                linear-gradient(rgba(0, 180, 255, 0.03) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0, 180, 255, 0.03) 1px, transparent 1px);
+            background-size: 60px 60px;
+            mask-image: radial-gradient(ellipse at center, black 0%, transparent 70%);
+        }
+
+        /* Navigation */
+        nav {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 100;
+            padding: 1.5rem 3rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: linear-gradient(to bottom, var(--void) 0%, transparent 100%);
+        }
+
+        .logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--manhattan-glow);
+            text-decoration: none;
+            letter-spacing: -0.02em;
+            text-shadow: 0 0 20px rgba(0, 212, 255, 0.5);
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2.5rem;
+            align-items: center;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s, text-shadow 0.3s;
+        }
+
+        .nav-links a:hover {
+            color: var(--manhattan-glow);
+            text-shadow: 0 0 15px rgba(0, 212, 255, 0.5);
+        }
+
+        .github-btn {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.6rem 1.2rem;
+            background: transparent;
+            border: 1px solid var(--border-subtle);
+            border-radius: 6px;
+            color: var(--text-primary);
+            text-decoration: none;
+            font-size: 0.85rem;
+            font-weight: 500;
+            transition: all 0.3s;
+        }
+
+        .github-btn:hover {
+            border-color: var(--manhattan-blue);
+            background: rgba(0, 180, 255, 0.1);
+            box-shadow: var(--glow-soft);
+        }
+
+        .github-btn svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        /* Hero Section */
+        .hero {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+            padding: 8rem 2rem 4rem;
+            position: relative;
+        }
+
+        .hero-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.4rem 1rem;
+            background: rgba(0, 180, 255, 0.1);
+            border: 1px solid var(--border-subtle);
+            border-radius: 100px;
+            font-size: 0.8rem;
+            color: var(--manhattan-glow);
+            margin-bottom: 2rem;
+            animation: fadeInUp 0.8s ease-out;
+        }
+
+        .hero-badge::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            background: var(--manhattan-glow);
+            border-radius: 50%;
+            box-shadow: 0 0 10px var(--manhattan-glow);
+            animation: pulse 2s infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        .hero h1 {
+            font-size: clamp(3rem, 8vw, 6rem);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.1;
+            margin-bottom: 1.5rem;
+            animation: fadeInUp 0.8s ease-out 0.1s both;
+        }
+
+        .hero h1 .glow {
+            color: var(--manhattan-glow);
+            text-shadow: var(--glow-intense);
+        }
+
+        .hero-tagline {
+            font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+            color: var(--text-secondary);
+            max-width: 600px;
+            margin-bottom: 3rem;
+            font-weight: 400;
+            animation: fadeInUp 0.8s ease-out 0.2s both;
+        }
+
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .hero-actions {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            justify-content: center;
+            animation: fadeInUp 0.8s ease-out 0.3s both;
+        }
+
+        .btn-primary {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.9rem 2rem;
+            background: linear-gradient(135deg, var(--manhattan-blue) 0%, var(--atomic-purple) 100%);
+            border: none;
+            border-radius: 8px;
+            color: white;
+            font-size: 1rem;
+            font-weight: 600;
+            font-family: inherit;
+            text-decoration: none;
+            cursor: pointer;
+            transition: all 0.3s;
+            box-shadow: 0 4px 20px rgba(0, 180, 255, 0.3);
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--glow-intense);
+        }
+
+        .btn-secondary {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.9rem 2rem;
+            background: transparent;
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            color: var(--text-primary);
+            font-size: 1rem;
+            font-weight: 500;
+            font-family: inherit;
+            text-decoration: none;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .btn-secondary:hover {
+            border-color: var(--manhattan-blue);
+            background: rgba(0, 180, 255, 0.1);
+        }
+
+        /* Exchanges Section */
+        .exchanges-preview {
+            display: flex;
+            gap: 3rem;
+            align-items: center;
+            justify-content: center;
+            margin-top: 5rem;
+            padding-top: 3rem;
+            border-top: 1px solid var(--border-subtle);
+            animation: fadeInUp 0.8s ease-out 0.4s both;
+        }
+
+        .exchanges-preview span {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .exchange-logos {
+            display: flex;
+            gap: 2rem;
+            align-items: center;
+        }
+
+        .exchange-logo {
+            width: 48px;
+            height: 48px;
+            border-radius: 12px;
+            object-fit: cover;
+            filter: grayscale(0.3);
+            opacity: 0.8;
+            transition: all 0.3s;
+        }
+
+        .exchange-logo:hover {
+            filter: grayscale(0);
+            opacity: 1;
+            transform: scale(1.1);
+            box-shadow: var(--glow-soft);
+        }
+
+        /* Code Preview Section */
+        .code-section {
+            padding: 8rem 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .section-header {
+            text-align: center;
+            margin-bottom: 4rem;
+        }
+
+        .section-header h2 {
+            font-size: clamp(2rem, 4vw, 2.75rem);
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            margin-bottom: 1rem;
+        }
+
+        .section-header p {
+            color: var(--text-secondary);
+            font-size: 1.1rem;
+            max-width: 500px;
+            margin: 0 auto;
+        }
+
+        .code-container {
+            position: relative;
+            background: var(--code-bg);
+            border: 1px solid var(--border-subtle);
+            border-radius: 16px;
+            overflow: hidden;
+            box-shadow:
+                0 4px 6px rgba(0, 0, 0, 0.3),
+                0 0 60px rgba(0, 180, 255, 0.1);
+        }
+
+        .code-header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 1rem 1.5rem;
+            background: rgba(0, 0, 0, 0.3);
+            border-bottom: 1px solid var(--border-subtle);
+        }
+
+        .code-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--text-muted);
+        }
+
+        .code-dot:nth-child(1) { background: #ff5f57; }
+        .code-dot:nth-child(2) { background: #ffbd2e; }
+        .code-dot:nth-child(3) { background: #28c840; }
+
+        .code-filename {
+            margin-left: auto;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+        }
+
+        .code-block {
+            padding: 2rem;
+            overflow-x: auto;
+        }
+
+        .code-block pre {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.9rem;
+            line-height: 1.8;
+        }
+
+        .code-block .comment { color: #6b737c; }
+        .code-block .keyword { color: var(--atomic-purple); }
+        .code-block .string { color: #7ec699; }
+        .code-block .function { color: var(--manhattan-glow); }
+        .code-block .variable { color: var(--text-primary); }
+        .code-block .property { color: #f78c6c; }
+        .code-block .number { color: #f78c6c; }
+
+        /* Features Section */
+        .features-section {
+            padding: 6rem 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .feature-card {
+            position: relative;
+            padding: 2rem;
+            background: linear-gradient(135deg, rgba(13, 13, 21, 0.8) 0%, rgba(10, 10, 16, 0.9) 100%);
+            border: 1px solid var(--border-subtle);
+            border-radius: 16px;
+            transition: all 0.4s;
+        }
+
+        .feature-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background: linear-gradient(90deg, transparent, var(--manhattan-blue), transparent);
+            opacity: 0;
+            transition: opacity 0.4s;
+        }
+
+        .feature-card:hover {
+            border-color: rgba(0, 180, 255, 0.3);
+            transform: translateY(-4px);
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 180, 255, 0.1);
+        }
+
+        .feature-card:hover::before {
+            opacity: 1;
+        }
+
+        .feature-icon {
+            width: 48px;
+            height: 48px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 180, 255, 0.1);
+            border-radius: 12px;
+            margin-bottom: 1.25rem;
+            color: var(--manhattan-glow);
+        }
+
+        .feature-icon svg {
+            width: 24px;
+            height: 24px;
+        }
+
+        .feature-card h3 {
+            font-size: 1.15rem;
+            font-weight: 600;
+            margin-bottom: 0.75rem;
+            letter-spacing: -0.01em;
+        }
+
+        .feature-card p {
+            color: var(--text-secondary);
+            font-size: 0.95rem;
+            line-height: 1.6;
+        }
+
+        /* Install Section */
+        .install-section {
+            padding: 6rem 2rem;
+            text-align: center;
+        }
+
+        .install-box {
+            display: inline-flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 1rem 1.5rem;
+            background: var(--code-bg);
+            border: 1px solid var(--border-subtle);
+            border-radius: 12px;
+            margin-top: 2rem;
+        }
+
+        .install-box code {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1rem;
+            color: var(--manhattan-glow);
+        }
+
+        .copy-btn {
+            padding: 0.5rem;
+            background: transparent;
+            border: none;
+            color: var(--text-muted);
+            cursor: pointer;
+            transition: color 0.3s;
+            border-radius: 6px;
+        }
+
+        .copy-btn:hover {
+            color: var(--manhattan-glow);
+            background: rgba(0, 180, 255, 0.1);
+        }
+
+        .copy-btn svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        /* Footer */
+        footer {
+            padding: 4rem 2rem;
+            text-align: center;
+            border-top: 1px solid var(--border-subtle);
+        }
+
+        .footer-links {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            margin-bottom: 2rem;
+        }
+
+        .footer-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.3s;
+        }
+
+        .footer-links a:hover {
+            color: var(--manhattan-glow);
+        }
+
+        .footer-copy {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            nav {
+                padding: 1rem 1.5rem;
+            }
+
+            .nav-links {
+                display: none;
+            }
+
+            .hero {
+                padding: 6rem 1.5rem 3rem;
+            }
+
+            .exchanges-preview {
+                flex-direction: column;
+                gap: 1.5rem;
+            }
+
+            .exchange-logos {
+                gap: 1.5rem;
+            }
+
+            .exchange-logo {
+                width: 40px;
+                height: 40px;
+            }
+
+            .code-block {
+                padding: 1.25rem;
+            }
+
+            .code-block pre {
+                font-size: 0.8rem;
+            }
+
+            .install-box {
+                flex-direction: column;
+                width: 100%;
+                max-width: 400px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="cosmic-bg"></div>
+    <div class="grid-overlay"></div>
+
+    <nav>
+        <a href="#" class="logo">dr-manhattan</a>
+        <div class="nav-links">
+            <a href="#features">Features</a>
+            <a href="#code">Examples</a>
+            <a href="#install">Install</a>
+            <a href="https://github.com/guzus/dr-manhattan" class="github-btn" target="_blank">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                GitHub
+            </a>
+        </div>
+    </nav>
+
+    <section class="hero">
+        <div class="hero-badge">Open Source</div>
+        <h1><span class="glow">dr-manhattan</span></h1>
+        <p class="hero-tagline">CCXT for prediction markets. Simple, scalable, and easy to extend.</p>
+        <div class="hero-actions">
+            <a href="#install" class="btn-primary">Get Started</a>
+            <a href="https://github.com/guzus/dr-manhattan" class="btn-secondary" target="_blank">View on GitHub</a>
+        </div>
+
+        <div class="exchanges-preview">
+            <span>Supported Exchanges</span>
+            <div class="exchange-logos">
+                <img src="assets/polymarket.png" alt="Polymarket" class="exchange-logo">
+                <img src="assets/kalshi.jpeg" alt="Kalshi" class="exchange-logo">
+                <img src="assets/opinion.jpg" alt="Opinion" class="exchange-logo">
+                <img src="assets/limitless.jpg" alt="Limitless" class="exchange-logo">
+            </div>
+        </div>
+    </section>
+
+    <section class="code-section" id="code">
+        <div class="section-header">
+            <h2>Simple, Unified Interface</h2>
+            <p>Write exchange-agnostic code that works across all prediction markets</p>
+        </div>
+
+        <div class="code-container">
+            <div class="code-header">
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-filename">example.py</span>
+            </div>
+            <div class="code-block">
+<pre><span class="keyword">import</span> <span class="variable">dr_manhattan</span>
+
+<span class="comment"># Initialize any exchange with the same interface</span>
+<span class="variable">polymarket</span> = <span class="variable">dr_manhattan</span>.<span class="function">Polymarket</span>({<span class="string">'timeout'</span>: <span class="number">30</span>})
+<span class="variable">opinion</span> = <span class="variable">dr_manhattan</span>.<span class="function">Opinion</span>({<span class="string">'timeout'</span>: <span class="number">30</span>})
+<span class="variable">limitless</span> = <span class="variable">dr_manhattan</span>.<span class="function">Limitless</span>({<span class="string">'timeout'</span>: <span class="number">30</span>})
+
+<span class="comment"># Fetch markets from any platform</span>
+<span class="variable">markets</span> = <span class="variable">polymarket</span>.<span class="function">fetch_markets</span>()
+
+<span class="keyword">for</span> <span class="variable">market</span> <span class="keyword">in</span> <span class="variable">markets</span>:
+    <span class="function">print</span>(<span class="string">f"</span><span class="variable">{market.question}</span><span class="string">: </span><span class="variable">{market.prices}</span><span class="string">"</span>)</pre>
+            </div>
+        </div>
+    </section>
+
+    <section class="features-section" id="features">
+        <div class="section-header">
+            <h2>Built for Developers</h2>
+            <p>Everything you need to build prediction market applications</p>
+        </div>
+
+        <div class="features-grid">
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+                </div>
+                <h3>Unified Interface</h3>
+                <p>One API to rule them all. Write code once and deploy across Polymarket, Kalshi, Opinion, and Limitless.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+                </div>
+                <h3>WebSocket Support</h3>
+                <p>Real-time market data streaming with built-in WebSocket connections for live orderbook and trade updates.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                </div>
+                <h3>Strategy Framework</h3>
+                <p>Base class for building trading strategies with order tracking, position management, and event logging.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                </div>
+                <h3>Easily Extensible</h3>
+                <p>Add new exchanges by implementing abstract methods. Clean architecture makes integration straightforward.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                </div>
+                <h3>Type Safe</h3>
+                <p>Full type hints throughout the codebase. Catch errors early and enjoy superior IDE autocomplete.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                </div>
+                <h3>Order Management</h3>
+                <p>Create, cancel, and track orders with standardized error handling across all supported exchanges.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="install-section" id="install">
+        <div class="section-header">
+            <h2>Get Started in Seconds</h2>
+            <p>Install with uv and start building</p>
+        </div>
+
+        <div class="install-box">
+            <code>uv pip install -e git+https://github.com/guzus/dr-manhattan</code>
+            <button class="copy-btn" onclick="copyInstall()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            </button>
+        </div>
+    </section>
+
+    <footer>
+        <div class="footer-links">
+            <a href="https://github.com/guzus/dr-manhattan" target="_blank">GitHub</a>
+            <a href="https://github.com/guzus/dr-manhattan/issues" target="_blank">Issues</a>
+            <a href="https://github.com/guzus/dr-manhattan#readme" target="_blank">Documentation</a>
+        </div>
+        <p class="footer-copy">MIT License. Built for the prediction market community.</p>
+    </footer>
+
+    <script>
+        function copyInstall() {
+            const text = 'uv pip install -e git+https://github.com/guzus/dr-manhattan';
+            navigator.clipboard.writeText(text);
+            const btn = document.querySelector('.copy-btn');
+            btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>';
+            setTimeout(() => {
+                btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+            }, 2000);
+        }
+
+        // Intersection Observer for fade-in animations
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.style.opacity = '1';
+                    entry.target.style.transform = 'translateY(0)';
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.feature-card').forEach((card, i) => {
+            card.style.opacity = '0';
+            card.style.transform = 'translateY(30px)';
+            card.style.transition = `all 0.6s ease-out ${i * 0.1}s`;
+            observer.observe(card);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` landing page with Dr. Manhattan-inspired dark cosmic theme
- Add GitHub Actions workflow for automatic deployment to GitHub Pages

## Features
- Responsive design with glowing blue accents
- Syntax-highlighted code examples
- Feature cards with hover animations
- Copy-to-clipboard install command
- Exchange logos section

## Setup Required
After merging, enable GitHub Pages in repo settings:
1. Go to Settings > Pages
2. Source: GitHub Actions

Site will be live at: https://guzus.github.io/dr-manhattan

🤖 Generated with [Claude Code](https://claude.com/claude-code)