### PR TITLE
docs: refresh exchange documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ polymarket = dr_manhattan.Polymarket({'timeout': 30})
 opinion = dr_manhattan.Opinion({'timeout': 30})
 limitless = dr_manhattan.Limitless({'timeout': 30})
 predictfun = dr_manhattan.PredictFun({'timeout': 30})
+kalshi = dr_manhattan.Kalshi({'timeout': 30})
 
 # Fetch markets
 markets = polymarket.fetch_markets()
@@ -168,11 +169,16 @@ strategy.run()
 from dr_manhattan import create_exchange, list_exchanges
 
 # List available exchanges
-print(list_exchanges())  # ['polymarket', 'limitless', 'opinion', 'predictfun']
+print(list_exchanges())  # ['polymarket', 'opinion', 'limitless', 'predictfun', 'kalshi']
 
-# Create exchange by name
-exchange = create_exchange('polymarket', {'timeout': 30})
+# Create exchange by name using environment credentials
+exchange = create_exchange('polymarket')
+
+# Read-only instance without requiring credentials
+public_exchange = create_exchange('polymarket', validate=False)
 ```
+
+Use `predictfun` with `create_exchange()` and CLI examples. The low-level `PredictFun.id` property is `predict.fun`, matching the venue name, but the factory key is `predictfun`.
 
 ### MCP Server
 
@@ -283,6 +289,7 @@ exchanges = {
     "opinion": Opinion,
     "limitless": Limitless,
     "predictfun": PredictFun,
+    "kalshi": Kalshi,
     "newexchange": NewExchange,
 }
 ```
@@ -335,6 +342,7 @@ uv run python examples/list_all_markets.py polymarket
 uv run python examples/list_all_markets.py opinion
 uv run python examples/list_all_markets.py limitless
 uv run python examples/list_all_markets.py predictfun
+uv run python examples/list_all_markets.py kalshi
 
 # Run spread strategy
 uv run python examples/spread_strategy.py --exchange polymarket --slug fed-decision

--- a/dr_manhattan/exchanges/polymarket/README.md
+++ b/dr_manhattan/exchanges/polymarket/README.md
@@ -3,6 +3,8 @@
 Unified Python client for the Polymarket prediction market platform.  
 Built as a mixin-based package — all methods are accessible directly on the `Polymarket` class.
 
+For current upstream API and SDK caveats, see [wiki/exchanges/polymarket.md](../../../wiki/exchanges/polymarket.md). This package README documents the local module layout and wrapper surface.
+
 ```python
 from dr_manhattan.exchanges import Polymarket
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -7,8 +7,10 @@ Documentation for the Dr. Manhattan prediction market trading library.
 Exchange-specific documentation:
 
 - [Polymarket](exchanges/polymarket.md) - Decentralized prediction market on Polygon
-- Opinion - Prediction market on BNB Chain
-- Limitless - Prediction market on Base
+- [Opinion](exchanges/opinion.md) - Prediction market on BNB Chain
+- [Limitless](exchanges/limitless.md) - Prediction market on Base
+- [Predict.fun](exchanges/predictfun.md) - Prediction market on BNB Chain
+- [Kalshi](exchanges/kalshi.md) - CFTC-regulated prediction market
 - [Template](exchanges/TEMPLATE.md) - Template for creating new exchange documentation
 
 ## MCP Server
@@ -213,10 +215,13 @@ dr_manhattan/
 │   ├── websocket.py        # Base WebSocket class
 │   └── errors.py           # Exception definitions
 ├── exchanges/
-│   ├── polymarket.py       # Polymarket implementation
-│   ├── polymarket_ws.py    # Polymarket WebSocket
+│   ├── polymarket/         # Polymarket package implementation
+│   ├── kalshi.py           # Kalshi implementation
 │   ├── opinion.py          # Opinion implementation
-│   └── limitless.py        # Limitless implementation
+│   ├── limitless.py        # Limitless implementation
+│   ├── limitless_ws.py     # Limitless WebSocket
+│   ├── predictfun.py       # Predict.fun implementation
+│   └── predictfun_ws.py    # Predict.fun WebSocket
 ├── models/
 │   ├── market.py           # Market model
 │   ├── order.py            # Order model
@@ -254,6 +259,10 @@ uv run python examples/test_polymarket_ws.py
 
 - [GitHub Repository](https://github.com/guzus/dr-manhattan)
 - [Polymarket Docs](https://docs.polymarket.com/)
+- [Kalshi Docs](https://docs.kalshi.com/)
+- [Opinion Docs](https://docs.opinion.trade/developer-guide/opinion-open-api/overview)
+- [Limitless Docs](https://limitless.mintlify.app/api-reference/introduction)
+- [Predict.fun Docs](https://dev.predict.fun/)
 
 ## Contributing
 

--- a/wiki/exchanges/kalshi.md
+++ b/wiki/exchanges/kalshi.md
@@ -6,12 +6,20 @@
 - **Exchange Name**: Kalshi
 - **Type**: Prediction Market (CFTC-regulated)
 - **Base Class**: [Exchange](../../dr_manhattan/base/exchange.py)
-- **REST API**: `https://api.elections.kalshi.com/trade-api/v2`
-- **Demo API**: `https://demo-api.kalshi.co/trade-api/v2`
-- **WebSocket API**: `wss://api.elections.kalshi.com`
+- **REST API used by this wrapper**: `https://api.elections.kalshi.com/trade-api/v2`
+- **Demo API used by this wrapper**: `https://demo-api.kalshi.co/trade-api/v2`
+- **Current documented WebSocket API**: `wss://external-api-ws.kalshi.com/trade-api/ws/v2`
+- **Current documented Demo WebSocket API**: `wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2`
 - **Documentation**: https://docs.kalshi.com/
 
 Kalshi is the first CFTC-regulated prediction market exchange in the United States. It offers binary event contracts on various topics including politics, economics, and current events. Prices are quoted in cents (1-99) and converted to decimals (0.01-0.99) in the SDK.
+
+## Current API Notes
+
+- Kalshi authentication signs `timestamp + method + path` with RSA-PSS/SHA256 and sends `KALSHI-ACCESS-KEY`, `KALSHI-ACCESS-SIGNATURE`, and `KALSHI-ACCESS-TIMESTAMP`.
+- Query parameters are not included in the signed path. The wrapper mirrors this by stripping `?` and everything after it before signing.
+- The official WebSocket API requires an authenticated session even for public market-data channels. This wrapper does not currently implement Kalshi WebSocket streaming; use REST methods or add a WebSocket adapter before relying on live deltas.
+- The official docs now emphasize `external-api` WebSocket hosts; this wrapper's REST defaults remain the legacy `api.elections.kalshi.com` and `demo-api.kalshi.co` hosts unless `api_url` is overridden.
 
 ## Table of Contents
 
@@ -311,8 +319,11 @@ Kalshi provides WebSocket connections for real-time data.
 
 ### WebSocket URL
 
-- Production: `wss://api.elections.kalshi.com`
-- Demo: `wss://demo-api.kalshi.co`
+- Production: `wss://external-api-ws.kalshi.com/trade-api/ws/v2`
+- Demo: `wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2`
+- Legacy shared hosts still noted by Kalshi docs: `wss://api.elections.kalshi.com/trade-api/ws/v2` and `wss://demo-api.kalshi.co/trade-api/ws/v2`
+
+This wrapper does not currently expose `get_websocket()` for Kalshi despite documenting the upstream protocol here.
 
 ### Authentication
 

--- a/wiki/exchanges/limitless.md
+++ b/wiki/exchanges/limitless.md
@@ -13,6 +13,14 @@
 
 Limitless is a prediction market platform built on Base chain with CLOB-style orderbook. It uses EIP-712 message signing for authentication and order placement.
 
+## Current API Notes
+
+- Current Limitless API docs list `https://api.limitless.exchange` as the base URL and describe HMAC-SHA256 scoped API tokens for authenticated integrations.
+- This wrapper currently authenticates by signing the `/auth/signing-message` challenge with an EOA private key and storing the returned session cookie. That matches older/web-session behavior, not the current documented scoped-token flow.
+- Public browsing, market detail, orderbook, search, feed events, and public portfolio endpoints do not require authentication. Trading, user orders, positions, allowance, and balances require authentication.
+- CLOB markets include venue `exchange` and `adapter` addresses. Order signing must use the market venue's `exchange` address as the EIP-712 verifying contract; do not hard-code one exchange contract across all markets.
+- USDC on Base has 6 decimals. Prices are represented as decimal probabilities in this wrapper, while signed order amounts are scaled before submission.
+
 ### Key Features
 
 - **CLOB Trading**: Central Limit Order Book for efficient price discovery

--- a/wiki/exchanges/opinion.md
+++ b/wiki/exchanges/opinion.md
@@ -7,10 +7,18 @@
 - **Type**: Prediction Market
 - **Base Class**: [Exchange](../../dr_manhattan/base/exchange.py)
 - **REST API**: `https://proxy.opinion.trade:8443`
+- **OpenAPI Documentation Host**: `https://openapi.opinion.trade`
 - **Chain**: BNB Chain (Chain ID: 56)
 - **Documentation**: https://docs.opinion.trade/developer-guide/opinion-open-api/overview
 
 Opinion is a prediction market platform built on BNB Chain. It supports both binary and categorical (multi-outcome) markets.
+
+## Current API Notes
+
+- Opinion's OpenAPI is a read-only data API; official docs direct trading, order management, positions, and on-chain actions to the Opinion CLOB SDK.
+- All OpenAPI requests require an `apikey` header. The wrapper also sends `Authorization: Bearer <api_key>` and `X-API-Key` for compatibility with the current SDK/proxy behavior.
+- The documented public rate limit is 15 requests per second per API key, and list endpoints are paginated with a maximum `limit` of 20.
+- The wrapper initializes `opinion_clob_sdk.Client` only when `api_key`, `private_key`, and `multi_sig_addr` are provided. Public methods that call SDK endpoints still need an API key.
 
 ### Key Features
 

--- a/wiki/exchanges/polymarket.md
+++ b/wiki/exchanges/polymarket.md
@@ -15,6 +15,12 @@
 
 Polymarket is a decentralized prediction market platform built on Polygon. Users can trade on the outcome of real-world events.
 
+## Current API Notes
+
+- Polymarket's current public docs preview unified TypeScript and Python SDKs. This repo still uses the `py-clob-client` dependency, so verify order placement against Polymarket's current SDK guidance before production trading.
+- Public market discovery is split across Gamma and CLOB data. For trading, resolve token IDs from market metadata and pass a concrete token ID when creating an order.
+- CLOB WebSockets expose market and user channels; user streams require the same API credential context as authenticated REST trading.
+
 ### Key Features
 
 - **Multiple APIs**: CLOB, Gamma, Data API, WebSocket, and GraphQL
@@ -29,7 +35,7 @@ Polymarket is a decentralized prediction market platform built on Polygon. Users
 - [Developer Quickstart](https://docs.polymarket.com/quickstart)
 - [API Showcase](https://docs.polymarket.com/quickstart/introduction/showcase)
 - [Discord Community](https://discord.gg/polymarket)
-- [Official Python Client](https://github.com/Polymarket/py-clob-client)
+- [Official SDKs](https://docs.polymarket.com/)
 
 ## Table of Contents
 
@@ -870,7 +876,7 @@ result = exchange.convert_no_tokens(
 ### Official SDKs
 
 **Python:**
-- [`py-clob-client`](https://github.com/Polymarket/py-clob-client) - Official Python client
+- Official Python SDK - see the current SDK links in [Polymarket Docs](https://docs.polymarket.com/)
 - [`polymarket-apis`](https://pypi.org/project/polymarket-apis/) - Unified API with Pydantic validation
 
 **TypeScript/JavaScript:**
@@ -1083,7 +1089,7 @@ except RateLimitError as e:
 
 Official open-source projects:
 
-- [py-clob-client](https://github.com/Polymarket/py-clob-client) - Python client library
+- Python SDK - see the current [Polymarket SDK docs](https://docs.polymarket.com/)
 - [clob-client](https://github.com/Polymarket/clob-client) - TypeScript/JavaScript client
 - [ctf-utils](https://github.com/Polymarket/ctf-utils) - Conditional Token Framework utilities
 - [subgraph](https://github.com/Polymarket/polymarket-subgraph) - GraphQL subgraph
@@ -1307,7 +1313,7 @@ exchange = Polymarket({
 
 ### GitHub Repositories
 
-- [py-clob-client](https://github.com/Polymarket/py-clob-client) - Official Python client
+- Python SDK - see the current [Polymarket SDK docs](https://docs.polymarket.com/)
 - [clob-client](https://github.com/Polymarket/clob-client) - Official TypeScript client
 - [ctf-utils](https://github.com/Polymarket/ctf-utils) - Conditional Token Framework utilities
 - [polymarket-subgraph](https://github.com/Polymarket/polymarket-subgraph) - GraphQL subgraph

--- a/wiki/exchanges/predictfun.md
+++ b/wiki/exchanges/predictfun.md
@@ -1,0 +1,225 @@
+# Predict.fun
+
+## Overview
+
+- **Exchange ID**: `predict.fun` on the low-level exchange class; `predictfun` in `create_exchange()` and CLI examples
+- **Exchange Name**: Predict.fun
+- **Type**: Prediction Market
+- **Base Class**: [Exchange](../../dr_manhattan/base/exchange.py)
+- **REST API**: `https://api.predict.fun`
+- **Testnet REST API**: `https://api-testnet.predict.fun`
+- **Chain**: BNB Chain mainnet (`56`) or BNB testnet (`97`)
+- **Documentation**: https://dev.predict.fun/
+
+Predict.fun is a BNB-native prediction market with REST and WebSocket APIs for market data, orders, account activity, positions, search, and OAuth/delegated flows. This wrapper supports both EOA signing and Predict Account smart-wallet signing.
+
+## Features
+
+### Supported Methods
+
+| Method | REST | WebSocket | Description |
+|--------|------|-----------|-------------|
+| `fetch_markets()` | Yes | No | Fetch active markets with pagination and filters |
+| `fetch_market()` | Yes | No | Fetch a specific market by ID |
+| `fetch_markets_by_slug()` | Yes | No | Resolve category/market slug or URL |
+| `search_markets()` | Yes | No | Search categories and markets |
+| `fetch_token_ids()` | Yes | No | Return outcome token IDs for a market |
+| `get_orderbook()` | Yes | Yes | Fetch orderbook by market ID or token ID |
+| `create_order()` | Yes | No | Create and submit signed orders |
+| `cancel_order()` | Yes | No | Remove an order from the orderbook |
+| `fetch_order()` | Yes | No | Fetch order by hash |
+| `fetch_open_orders()` | Yes | No | List active user orders |
+| `fetch_positions()` | Yes | No | List user positions |
+| `fetch_balance()` | On-chain | No | Read USDT collateral balance |
+| `get_websocket()` | No | Yes | Market WebSocket |
+| `get_user_websocket()` | No | Yes | Authenticated user WebSocket |
+
+### Exchange Capabilities
+
+```python
+exchange.describe()
+# Returns id/name, host, chain_id, testnet, wallet mode, and supported methods.
+```
+
+## Authentication
+
+### Public API
+
+Predict.fun mainnet requires an API key for API access. Testnet does not require an API key according to the official docs.
+
+```python
+from dr_manhattan.exchanges.predictfun import PredictFun
+
+exchange = PredictFun({
+    "api_key": "your_api_key",
+})
+markets = exchange.fetch_markets({"limit": 20})
+```
+
+### EOA Trading
+
+```python
+exchange = PredictFun({
+    "api_key": "your_api_key",
+    "private_key": "your_eoa_private_key",
+})
+```
+
+The wrapper requests `/v1/auth/message`, signs the returned message, exchanges it for a JWT, and signs orders using the Predict.fun CTF Exchange EIP-712 domain.
+
+### Predict Account / Smart Wallet Trading
+
+```python
+exchange = PredictFun({
+    "api_key": "your_api_key",
+    "use_smart_wallet": True,
+    "smart_wallet_address": "0xYourPredictAccount",
+    "smart_wallet_owner_private_key": "your_privy_wallet_private_key",
+})
+```
+
+Predict.fun's docs state that web app users have a Predict Account smart wallet. Programmatic smart-wallet access needs the Predict account address and the Privy wallet private key exported from account settings.
+
+**Configuration Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_key` | str | Mainnet yes | API key from Predict.fun support |
+| `private_key` | str | EOA trading | EOA private key for auth and order signing |
+| `use_smart_wallet` | bool | No | Enable Predict Account signing |
+| `smart_wallet_address` | str | Smart wallet trading | Predict Account/deposit address |
+| `smart_wallet_owner_private_key` | str | Smart wallet trading | Owner/Privy wallet private key |
+| `testnet` | bool | No | Use BNB testnet and `https://api-testnet.predict.fun` |
+| `host` | str | No | Override API host |
+| `timeout` | int | No | HTTP timeout |
+| `verbose` | bool | No | Enable request/debug logging |
+
+## Rate Limiting
+
+Official docs list 240 requests per minute on testnet without an API key and 240 requests per minute by default on mainnet API keys. Tune the base `Exchange` retry settings if running crawlers or market makers.
+
+```python
+exchange = PredictFun({
+    "api_key": "your_api_key",
+    "rate_limit": 4,
+    "max_retries": 3,
+    "retry_delay": 1.0,
+    "retry_backoff": 2.0,
+})
+```
+
+## Market Data
+
+### fetch_markets()
+
+```python
+markets = exchange.fetch_markets({
+    "limit": 20,
+    "status": "active",
+})
+```
+
+The wrapper maps Predict.fun market responses into `Market` with outcomes, token IDs in metadata, prices, liquidity, volume, close time, and market status. It also caches token-to-market mappings so `get_orderbook(token_id)` can work after markets have been fetched.
+
+### fetch_market()
+
+```python
+market = exchange.fetch_market("market_id")
+```
+
+Market IDs are Predict.fun market IDs. Use `fetch_markets_by_slug()` for category or market URLs.
+
+### get_orderbook()
+
+```python
+book = exchange.get_orderbook("market_id_or_token_id")
+```
+
+For a second outcome/no token, the wrapper may invert YES-side prices to match the unified orderbook shape. Fetch market metadata first when you plan to address books by token ID.
+
+## Trading
+
+### create_order()
+
+```python
+from dr_manhattan.models.order import OrderSide
+
+order = exchange.create_order(
+    market_id="market_id",
+    outcome="Yes",
+    side=OrderSide.BUY,
+    price=0.52,
+    size=100,
+    params={"token_id": "outcome_token_id"},
+)
+```
+
+Operational caveats:
+
+- `api_key` plus EOA or smart-wallet signing credentials are required.
+- The wrapper can check and set collateral/exchange approvals before trading.
+- Predict.fun uses USDT collateral on BNB Chain. Keep BNB available for approval and other on-chain transactions.
+- `params` can carry order options such as expiration and self-trade-prevention strategy; keep values aligned with the official Predict.fun schema.
+
+### cancel_order()
+
+```python
+order = exchange.cancel_order("order_hash")
+```
+
+Cancels are authenticated API calls and return the unified `Order` model where possible.
+
+## Account
+
+### fetch_balance()
+
+```python
+balance = exchange.fetch_balance()
+# {"USDT": ..., "free": ..., "used": ..., "total": ...}
+```
+
+Balance is read from the configured BNB Chain USDT contract for the active wallet address. In smart-wallet mode the active address is `smart_wallet_address`; in EOA mode it is derived from `private_key`.
+
+### fetch_positions()
+
+```python
+positions = exchange.fetch_positions()
+positions_for_market = exchange.fetch_positions("market_id")
+```
+
+Authenticated position APIs require a valid JWT. The wrapper refreshes authentication on demand.
+
+## WebSocket
+
+```python
+ws = exchange.get_websocket()
+user_ws = exchange.get_user_websocket()
+```
+
+Predict.fun docs include WebSocket request/response formats, subscription topics, heartbeats, and a client example. Use the market WebSocket for orderbook/market subscriptions and the user WebSocket for authenticated order or position updates.
+
+## Operational Notes
+
+- Mainnet API keys are requested through the Predict.fun Discord support flow.
+- The REST API is explicitly marked beta in official docs. Keep strategy code tolerant of schema additions, transient 4xx/5xx responses, and WebSocket reconnects.
+- Official docs list primary infrastructure in `ap-northeast-1`; colocated or Asia-region runners should see lower latency.
+- Factory usage differs from the exchange property: `create_exchange("predictfun", validate=False)` is correct, while `PredictFun().id` returns `predict.fun`.
+
+## Examples
+
+```python
+from dr_manhattan import create_exchange
+
+exchange = create_exchange("predictfun", validate=False)
+for market in exchange.fetch_markets({"limit": 10}):
+    print(market.id, market.question)
+```
+
+```bash
+uv run python examples/list_all_markets.py predictfun --limit 20
+```
+
+## Sources
+
+- Predict.fun Developer Documentation: https://dev.predict.fun/
+- Predict.fun Python SDK: https://github.com/PredictDotFun/sdk-python


### PR DESCRIPTION
## Summary
- add a Predict.fun exchange wiki page using the existing exchange docs structure
- update the exchange wiki index and README examples for the current supported exchange set
- document current upstream API caveats for Polymarket, Kalshi, Opinion, Limitless, and Predict.fun

## Verification
- git diff --cached --check
- uv run python - <<'PY'
from dr_manhattan import create_exchange, list_exchanges

print(list_exchanges())
for name in list_exchanges():
    exchange = create_exchange(name, validate=False)
    print(name, exchange.id)
PY