### PR TITLE
[codex] Update Predict.fun exchange driver

### DIFF
--- a/dr_manhattan/exchanges/predictfun.py
+++ b/dr_manhattan/exchanges/predictfun.py
@@ -9,7 +9,9 @@ API Documentation: https://dev.predict.fun/
 
 import secrets
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import requests
 from eth_abi import encode as eth_abi_encode
@@ -172,6 +174,8 @@ class PredictFun(Exchange):
         self._token_to_market: Dict[str, str] = {}
         # Token ID to outcome index (0=Yes, 1=No for binary markets)
         self._token_to_index: Dict[str, int] = {}
+        # Market ID to decimal precision, used when complementing Yes prices to No.
+        self._market_decimal_precision: Dict[str, int] = {}
 
         # Web3 connection for on-chain balance queries and approvals
         self._web3 = Web3(Web3.HTTPProvider(self._rpc_url))
@@ -464,18 +468,27 @@ class PredictFun(Exchange):
         description = data.get("description", "")
 
         outcomes_data = data.get("outcomes", [])
-        outcomes = [o.get("name", "") for o in outcomes_data if o.get("name")]
-        token_ids = [str(o.get("onChainId", "")) for o in outcomes_data if o.get("onChainId")]
+        outcomes = [
+            o.get("name") or o.get("label") or o.get("title") or ""
+            for o in outcomes_data
+            if isinstance(o, dict) and (o.get("name") or o.get("label") or o.get("title"))
+        ]
+        token_ids = [
+            str(o.get("onChainId") or o.get("tokenId") or o.get("token_id") or "")
+            for o in outcomes_data
+            if isinstance(o, dict) and (o.get("onChainId") or o.get("tokenId") or o.get("token_id"))
+        ]
 
         if not outcomes:
             outcomes = ["Yes", "No"]
 
-        status = data.get("status", "")
-        # REGISTERED = active, RESOLVED/PAUSED = closed
-        closed = status not in ("REGISTERED", "ACTIVE", "OPEN", "")
+        status = self._enum_value(data.get("status", ""))
+        trading_status = self._enum_value(data.get("tradingStatus", ""))
+        closed = self._is_market_closed(status, trading_status)
 
         decimal_precision = data.get("decimalPrecision", 2)
         tick_size = 10 ** (-decimal_precision)
+        self._market_decimal_precision[market_id] = int(decimal_precision)
 
         # Volume and liquidity
         volume = float(data.get("volume", 0) or 0)
@@ -488,11 +501,15 @@ class PredictFun(Exchange):
             **data,
             "clobTokenIds": token_ids,
             "token_ids": token_ids,
+            "tokens": dict(zip(outcomes, token_ids)),
             "isNegRisk": data.get("isNegRisk", False),
             "isYieldBearing": data.get("isYieldBearing", True),
             "conditionId": data.get("conditionId", ""),
             "feeRateBps": data.get("feeRateBps", 0),
             "categorySlug": data.get("categorySlug", ""),
+            "marketVariant": self._enum_value(data.get("marketVariant", "")),
+            "status": status,
+            "tradingStatus": trading_status,
             "closed": closed,
             "minimum_tick_size": tick_size,
         }
@@ -507,7 +524,7 @@ class PredictFun(Exchange):
             id=market_id,
             question=question,
             outcomes=outcomes,
-            close_time=None,
+            close_time=self._parse_datetime(data.get("endsAt") or data.get("closedAt")),
             volume=volume,
             liquidity=liquidity,
             prices=prices,
@@ -515,6 +532,31 @@ class PredictFun(Exchange):
             tick_size=tick_size,
             description=description,
         )
+
+    @staticmethod
+    def _enum_value(value: Any) -> str:
+        """Normalize enum values from string or object-shaped API responses."""
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict):
+            for key in ("value", "name", "status", "type"):
+                if value.get(key) is not None:
+                    return str(value[key])
+        return str(value)
+
+    @staticmethod
+    def _is_market_closed(status: str, trading_status: str) -> bool:
+        """Return true when the market is not open for new spread orders."""
+        status_upper = status.upper()
+        trading_upper = trading_status.upper()
+
+        if status_upper in {"RESOLVED", "REMOVED", "PAUSED"}:
+            return True
+        if trading_upper in {"CLOSED", "CANCEL_ONLY", "MATCHING_NOT_ENABLED"}:
+            return True
+        return False
 
     def _parse_order(self, data: Dict[str, Any], outcome: str = "") -> Order:
         """Parse order data from API response."""
@@ -530,6 +572,17 @@ class PredictFun(Exchange):
             or data.get("orderHash", "")
         )
         market_id = str(data.get("marketId", ""))
+        token_id = str(nested_order.get("tokenId") or data.get("tokenId") or "")
+        if not outcome and token_id:
+            outcome_index = self._token_to_index.get(token_id)
+            if outcome_index is not None:
+                try:
+                    market = self.fetch_market(self._token_to_market.get(token_id, market_id))
+                    if 0 <= outcome_index < len(market.outcomes):
+                        outcome = market.outcomes[outcome_index]
+                except Exception:
+                    # Binary Predict.fun markets conventionally order tokens as Yes, No.
+                    outcome = "Yes" if outcome_index == 0 else "No"
 
         # Parse side from nested order or top level
         side_raw = nested_order.get("side") if nested_order else data.get("side", "buy")
@@ -626,8 +679,33 @@ class PredictFun(Exchange):
         amount_wei = int(data.get("amount", 0) or 0)
         size = amount_wei / 1e18 if amount_wei > 0 else float(data.get("size", 0) or 0)
 
-        average_price = float(data.get("avgPrice", 0) or 0)
-        current_price = float(data.get("currentPrice", 0) or 0)
+        average_price = float(
+            data.get("averageBuyPriceUsd") or data.get("avgPrice") or data.get("average_price") or 0
+        )
+        current_price = float(
+            data.get("currentPrice") or data.get("current_price") or data.get("price") or 0
+        )
+        value_usd = float(data.get("valueUsd", 0) or 0)
+        if current_price <= 0 and size > 0 and value_usd >= 0:
+            current_price = value_usd / size
+
+        if current_price <= 0 and isinstance(outcome_data, dict):
+            status = str(outcome_data.get("status") or "").upper()
+            if status == "WON":
+                current_price = 1.0
+            elif status == "LOST":
+                current_price = 0.0
+            else:
+                best_bid = outcome_data.get("bestBid") or {}
+                best_ask = outcome_data.get("bestAsk") or {}
+                bid = float(best_bid.get("price", 0) or 0) if isinstance(best_bid, dict) else 0
+                ask = float(best_ask.get("price", 0) or 0) if isinstance(best_ask, dict) else 0
+                if bid > 0 and ask > 0:
+                    current_price = (bid + ask) / 2
+                elif bid > 0:
+                    current_price = bid
+                elif ask > 0:
+                    current_price = ask
 
         return Position(
             market_id=market_id,
@@ -671,12 +749,12 @@ class PredictFun(Exchange):
         fetch_all = query_params.get("all", False)
 
         all_markets: List[Market] = []
-        cursor = None
+        cursor = query_params.get("after")
         max_pages = 10 if fetch_all else 1
 
         for _ in range(max_pages):
-            api_params = {"first": min(limit, 100)}
-            if query_params.get("active", True):
+            api_params = self._build_markets_params(query_params, limit)
+            if query_params.get("active", True) and "status" not in api_params:
                 api_params["status"] = "OPEN"
             if cursor:
                 api_params["after"] = cursor
@@ -697,6 +775,22 @@ class PredictFun(Exchange):
             all_markets = all_markets[:limit]
 
         return all_markets
+
+    def _build_markets_params(self, params: Dict[str, Any], limit: int) -> Dict[str, Any]:
+        """Build current Predict.fun /v1/markets query parameters."""
+        api_params: Dict[str, Any] = {"first": min(int(limit or 100), 100)}
+        passthrough = {
+            "first",
+            "status",
+            "tagIds",
+            "marketVariant",
+            "sort",
+            "hasActiveRewards",
+        }
+        for key in passthrough:
+            if key in params and params[key] is not None:
+                api_params[key] = params[key]
+        return api_params
 
     def fetch_market(self, market_id: str) -> Market:
         """
@@ -763,7 +857,14 @@ class PredictFun(Exchange):
         except ExchangeError:
             pass  # Category not found, fall back to keyword search
 
-        # Fallback: keyword search
+        # Fallback: current full-text search API
+        if not markets:
+            try:
+                markets = self.search_markets(slug.replace("-", " "), limit=25)
+            except ExchangeError:
+                markets = []
+
+        # Final fallback: keyword scan through paginated markets
         if not markets:
             markets = self._search_markets_by_keywords(slug)
 
@@ -813,11 +914,60 @@ class PredictFun(Exchange):
 
         # Handle predict.fun URLs
         if "predict.fun" in slug:
-            # Extract slug from URL like https://predict.fun/markets/slug-here
-            parts = slug.rstrip("/").split("/")
+            parsed = urlparse(slug)
+            parts = [p for p in parsed.path.split("/") if p]
             slug = parts[-1] if parts else ""
 
         return slug
+
+    def search_markets(
+        self,
+        query: str,
+        limit: int = 25,
+        include_resolved: bool = False,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[Market]:
+        """
+        Search Predict.fun categories and markets using the current /v1/search API.
+
+        Category hits include nested markets, which is useful for grouped sports
+        markets like "2026 FIFA World Cup Winner".
+        """
+        query = query.strip()
+        if not query:
+            return []
+
+        request_params: Dict[str, Any] = {
+            "query": query,
+            "limit": str(max(1, min(int(limit), 25))),
+            "includeResolved": "true" if include_resolved else "false",
+        }
+        if params:
+            request_params.update(params)
+
+        response = self._request("GET", "/v1/search", params=request_params)
+        data = response.get("data", {}) if isinstance(response, dict) else {}
+
+        ordered: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+
+        def add_market(raw: Dict[str, Any]) -> None:
+            market_id = str(raw.get("id", ""))
+            if not market_id or market_id in seen:
+                return
+            seen.add(market_id)
+            ordered.append(raw)
+
+        for category in data.get("categories", []) or []:
+            for market in category.get("markets", []) or []:
+                if isinstance(market, dict):
+                    add_market(market)
+
+        for market in data.get("markets", []) or []:
+            if isinstance(market, dict):
+                add_market(market)
+
+        return [self._parse_market(market) for market in ordered]
 
     def _parse_category_as_market(self, data: Dict[str, Any]) -> Market:
         """Parse category data as a Market when it contains a single market."""
@@ -862,6 +1012,13 @@ class PredictFun(Exchange):
         if not keywords:
             return []
 
+        try:
+            search_results = self.search_markets(" ".join(keywords), limit=25)
+            if search_results:
+                return search_results
+        except ExchangeError:
+            pass
+
         all_markets = self.fetch_markets({"all": True})
 
         matches = []
@@ -871,6 +1028,36 @@ class PredictFun(Exchange):
                 matches.append(market)
 
         return matches
+
+    @staticmethod
+    def _parse_orderbook_level(entry: Any) -> Optional[Dict[str, str]]:
+        """Parse Predict.fun orderbook levels from tuple or dict shape."""
+        try:
+            if isinstance(entry, dict):
+                price = float(entry.get("price", 0))
+                size = float(entry.get("size", 0))
+            elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+                price = float(entry[0])
+                size = float(entry[1])
+            else:
+                return None
+        except (TypeError, ValueError):
+            return None
+
+        if price <= 0 or size <= 0:
+            return None
+        return {"price": str(price), "size": str(size)}
+
+    def _invert_yes_price(self, price: str, market_id: str) -> str:
+        """Complement a Yes price to the No side at the market's decimal precision."""
+        precision = self._market_decimal_precision.get(str(market_id), 2)
+        try:
+            quant = Decimal("1").scaleb(-precision)
+            inverted = (Decimal("1") - Decimal(str(price))).quantize(quant)
+        except (InvalidOperation, ValueError):
+            inverted = Decimal(str(1.0 - float(price)))
+
+        return format(inverted.normalize(), "f")
 
     def get_orderbook(self, market_id_or_token_id: str) -> Dict[str, Any]:
         """
@@ -909,31 +1096,40 @@ class PredictFun(Exchange):
                 if is_second_outcome:
                     # For second outcome (No), invert prices: No bid = 1 - Yes ask
                     for entry in raw_asks:
-                        if len(entry) >= 2:
-                            inverted_price = 1.0 - float(entry[0])
-                            if inverted_price > 0:
-                                bids.append({"price": str(inverted_price), "size": str(entry[1])})
+                        level = self._parse_orderbook_level(entry)
+                        if level:
+                            inverted_price = self._invert_yes_price(level["price"], market_id)
+                            if float(inverted_price) > 0:
+                                bids.append({"price": inverted_price, "size": level["size"]})
 
                     for entry in raw_bids:
-                        if len(entry) >= 2:
-                            inverted_price = 1.0 - float(entry[0])
-                            if inverted_price > 0:
-                                asks.append({"price": str(inverted_price), "size": str(entry[1])})
+                        level = self._parse_orderbook_level(entry)
+                        if level:
+                            inverted_price = self._invert_yes_price(level["price"], market_id)
+                            if float(inverted_price) > 0:
+                                asks.append({"price": inverted_price, "size": level["size"]})
                 else:
                     # First outcome (Yes) - use as-is
                     for entry in raw_bids:
-                        if len(entry) >= 2:
-                            bids.append({"price": str(entry[0]), "size": str(entry[1])})
+                        level = self._parse_orderbook_level(entry)
+                        if level:
+                            bids.append(level)
 
                     for entry in raw_asks:
-                        if len(entry) >= 2:
-                            asks.append({"price": str(entry[0]), "size": str(entry[1])})
+                        level = self._parse_orderbook_level(entry)
+                        if level:
+                            asks.append(level)
 
                 # Sort: bids descending, asks ascending
                 bids.sort(key=lambda x: float(x["price"]), reverse=True)
                 asks.sort(key=lambda x: float(x["price"]))
 
-                return {"bids": bids, "asks": asks}
+                return {
+                    "bids": bids,
+                    "asks": asks,
+                    "market_id": str(data.get("marketId", market_id)),
+                    "timestamp": data.get("updateTimestampMs", 0),
+                }
             except Exception as e:
                 if self.verbose:
                     print(f"Failed to fetch orderbook for {market_id}: {e}")
@@ -983,7 +1179,10 @@ class PredictFun(Exchange):
             params: Additional parameters:
                 - token_id: Token ID (optional if outcome provided)
                 - strategy: "LIMIT" or "MARKET" (default: "LIMIT")
+                - allow_market_order: Must be True when strategy="MARKET"
                 - slippageBps: Slippage in basis points (default: "0")
+                - reserved_balance_policy: "REJECT_MARKET_ORDER" or
+                  "SKIP_RESERVED_BALANCE_CHECKS" (market orders only)
 
         Returns:
             Order object
@@ -1037,7 +1236,7 @@ class PredictFun(Exchange):
         else:
             exchange_address = self._neg_risk_ctf_exchange if is_neg_risk else self._ctf_exchange
 
-        strategy = (extra_params.get("strategy", "LIMIT")).upper()
+        strategy = self._normalize_order_strategy(extra_params)
 
         signed_order = self._build_signed_order(
             token_id=str(token_id),
@@ -1060,12 +1259,13 @@ class PredictFun(Exchange):
                 "order": signed_order,
             }
         }
+        self._apply_create_order_options(payload["data"], extra_params)
 
         @self._retry_on_failure
         def _create():
             result = self._request("POST", "/v1/orders", data=payload, require_auth=True)
             order_data = result.get("data", result)
-            order_id = order_data.get("hash", "") or order_data.get("orderHash", "")
+            order_id = self._extract_created_order_id(order_data)
 
             return Order(
                 id=str(order_id),
@@ -1080,6 +1280,70 @@ class PredictFun(Exchange):
             )
 
         return _create()
+
+    @staticmethod
+    def _normalize_order_strategy(params: Dict[str, Any]) -> str:
+        """Normalize and guard Predict.fun order strategy selection."""
+        strategy = str(params.get("strategy", "LIMIT")).upper()
+        if strategy not in {"LIMIT", "MARKET"}:
+            raise InvalidOrder(f"Unsupported Predict.fun order strategy: {strategy}")
+        if strategy == "MARKET" and not (
+            params.get("allow_market_order") or params.get("allow_market_orders")
+        ):
+            raise InvalidOrder(
+                "Predict.fun MARKET orders require params['allow_market_order']=True"
+            )
+        return strategy
+
+    @staticmethod
+    def _extract_created_order_id(order_data: Dict[str, Any]) -> str:
+        """Prefer the API database order ID, which /v1/orders/remove expects."""
+        return str(
+            order_data.get("orderId")
+            or order_data.get("id")
+            or order_data.get("hash")
+            or order_data.get("orderHash")
+            or ""
+        )
+
+    @staticmethod
+    def _apply_create_order_options(data: Dict[str, Any], params: Dict[str, Any]) -> None:
+        """Apply current optional /v1/orders fields without forcing every caller to use them."""
+        strategy = str(data.get("strategy", "LIMIT")).upper()
+        reserved_aliases = ("reservedBalancePolicy", "reserved_balance_policy")
+        if strategy == "LIMIT" and any(
+            alias in params and params[alias] is not None for alias in reserved_aliases
+        ):
+            raise InvalidOrder("reservedBalancePolicy is only valid for Predict.fun MARKET orders")
+
+        option_aliases = {
+            "isFillOrKill": ("isFillOrKill", "fill_or_kill"),
+            "isPostOnly": ("isPostOnly", "post_only"),
+            "reservedBalancePolicy": ("reservedBalancePolicy", "reserved_balance_policy"),
+            "isMinAmountOut": ("isMinAmountOut", "is_min_amount_out"),
+            "selfTradePrevention": ("selfTradePrevention", "self_trade_prevention"),
+        }
+        for api_key, aliases in option_aliases.items():
+            for alias in aliases:
+                if alias in params and params[alias] is not None:
+                    value = params[alias]
+                    if api_key == "reservedBalancePolicy":
+                        value = str(value).upper()
+                        if value not in {
+                            "REJECT_MARKET_ORDER",
+                            "SKIP_RESERVED_BALANCE_CHECKS",
+                        }:
+                            raise InvalidOrder(
+                                f"Unsupported Predict.fun reservedBalancePolicy: {value}"
+                            )
+                    elif api_key == "selfTradePrevention":
+                        value = str(value).upper()
+                        if value not in {"CANCEL_MAKER", "CANCEL_TAKER", "CANCEL_BOTH"}:
+                            raise InvalidOrder(
+                                f"Unsupported Predict.fun selfTradePrevention: {value}"
+                            )
+                    data[api_key] = value
+                    break
 
     def _is_using_smart_wallet(self) -> bool:
         """Check if using a Predict smart wallet."""
@@ -1434,7 +1698,94 @@ class PredictFun(Exchange):
 
         return _fetch()
 
-    def fetch_open_orders(self, market_id: Optional[str] = None) -> List[Order]:
+    def fetch_orders(
+        self,
+        market_id: Optional[str] = None,
+        status: Optional[Any] = None,
+        limit: Optional[int] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[Order]:
+        """
+        Fetch authenticated order history.
+
+        Args:
+            market_id: Optional market filter. The API may ignore this, so the
+                driver also applies a client-side filter.
+            status: Optional Predict.fun status filter, e.g. OPEN, FILLED,
+                CANCELLED, EXPIRED, or INVALIDATED.
+            limit: Optional page size mapped to the API's ``first`` parameter.
+            params: Additional query parameters such as ``after``.
+
+        Returns:
+            List of Order objects.
+        """
+        self._ensure_authenticated()
+
+        query_params: Dict[str, Any] = dict(params or {})
+        if limit is not None and "first" not in query_params:
+            query_params["first"] = max(1, min(int(limit), 100))
+        if status is not None:
+            query_params["status"] = self._normalize_order_status_filter(status)
+        if market_id:
+            query_params["marketId"] = market_id
+
+        @self._retry_on_failure
+        def _fetch():
+            response = self._request("GET", "/v1/orders", params=query_params, require_auth=True)
+            orders_data = response if isinstance(response, list) else response.get("data", [])
+            if market_id:
+                orders_data = [
+                    order
+                    for order in orders_data
+                    if str(order.get("marketId", "")) == str(market_id)
+                ]
+            return [self._parse_order(o) for o in orders_data]
+
+        return _fetch()
+
+    @staticmethod
+    def _normalize_order_status_filter(status: Any) -> str:
+        if isinstance(status, OrderStatus):
+            return status.value.upper()
+        return str(status).upper()
+
+    def fetch_order_matches(
+        self,
+        market_id: Optional[str] = None,
+        signer_address: Optional[str] = None,
+        limit: Optional[int] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch raw Predict.fun order match events.
+
+        The API returns match/fill events sorted by ``executedAt`` descending.
+        The repository does not yet have a unified fill model, so this method
+        deliberately returns the raw event dictionaries.
+        """
+        query_params: Dict[str, Any] = dict(params or {})
+        if limit is not None and "first" not in query_params:
+            query_params["first"] = max(1, min(int(limit), 100))
+        if market_id:
+            query_params["marketId"] = market_id
+        if signer_address:
+            query_params["signerAddress"] = signer_address
+
+        @self._retry_on_failure
+        def _fetch():
+            response = self._request(
+                "GET",
+                "/v1/orders/matches",
+                params=query_params,
+                require_auth=False,
+            )
+            return response if isinstance(response, list) else response.get("data", [])
+
+        return _fetch()
+
+    def fetch_open_orders(
+        self, market_id: Optional[str] = None, params: Optional[Dict[str, Any]] = None
+    ) -> List[Order]:
         """
         Fetch all open orders.
 
@@ -1444,19 +1795,7 @@ class PredictFun(Exchange):
         Returns:
             List of Order objects
         """
-        self._ensure_authenticated()
-
-        query_params = {"status": "OPEN"}
-        if market_id:
-            query_params["marketId"] = market_id
-
-        @self._retry_on_failure
-        def _fetch():
-            response = self._request("GET", "/v1/orders", params=query_params, require_auth=True)
-            orders_data = response if isinstance(response, list) else response.get("data", [])
-            return [self._parse_order(o) for o in orders_data]
-
-        return _fetch()
+        return self.fetch_orders(market_id=market_id, status=OrderStatus.OPEN, params=params)
 
     def fetch_positions(self, market_id: Optional[str] = None) -> List[Position]:
         """

--- a/tests/test_predictfun.py
+++ b/tests/test_predictfun.py
@@ -1,0 +1,411 @@
+import pytest
+
+from dr_manhattan.base.errors import ExchangeError, InvalidOrder
+from dr_manhattan.exchanges.predictfun import PredictFun
+from dr_manhattan.models.order import OrderStatus
+
+
+def test_parse_market_current_schema_metadata_and_tokens():
+    exchange = PredictFun({"api_key": "test"})
+
+    market = exchange._parse_market(
+        {
+            "id": 1518,
+            "title": "Spain",
+            "question": "Will Spain win the 2026 FIFA World Cup?",
+            "description": "Resolves to Yes if Spain wins.",
+            "tradingStatus": "OPEN",
+            "status": "REGISTERED",
+            "isNegRisk": False,
+            "isYieldBearing": True,
+            "feeRateBps": 0,
+            "conditionId": "0xabc",
+            "categorySlug": "2026-fifa-world-cup-winner",
+            "decimalPrecision": 3,
+            "marketVariant": "SPORTS_TEAM_MATCH",
+            "outcomes": [
+                {"name": "Yes", "indexSet": 1, "onChainId": "111"},
+                {"name": "No", "indexSet": 2, "onChainId": "222"},
+            ],
+        }
+    )
+
+    assert market.id == "1518"
+    assert market.outcomes == ["Yes", "No"]
+    assert market.tick_size == 0.001
+    assert market.is_open is True
+    assert market.metadata["clobTokenIds"] == ["111", "222"]
+    assert market.metadata["tokens"] == {"Yes": "111", "No": "222"}
+    assert market.metadata["marketVariant"] == "SPORTS_TEAM_MATCH"
+    assert exchange._token_to_market["111"] == "1518"
+    assert exchange._token_to_index["222"] == 1
+
+
+def test_parse_market_treats_cancel_only_as_closed():
+    exchange = PredictFun({"api_key": "test"})
+
+    market = exchange._parse_market(
+        {
+            "id": 1,
+            "title": "Closed market",
+            "tradingStatus": "CANCEL_ONLY",
+            "status": "REGISTERED",
+            "outcomes": [],
+        }
+    )
+
+    assert market.is_open is False
+
+
+def test_parse_position_current_schema_uses_value_usd():
+    exchange = PredictFun({"api_key": "test"})
+
+    position = exchange._parse_position(
+        {
+            "amount": "100000000000000000000",
+            "averageBuyPriceUsd": "0.12",
+            "valueUsd": "1",
+            "market": {"id": 374798},
+            "outcome": {"name": "Yes"},
+        }
+    )
+
+    assert position.market_id == "374798"
+    assert position.outcome == "Yes"
+    assert position.size == 100
+    assert position.average_price == 0.12
+    assert position.current_price == 0.01
+    assert position.current_value == 1
+    assert position.unrealized_pnl == -11
+
+
+def test_fetch_markets_forwards_current_filters(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+    captured = {}
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        captured.update({"method": method, "endpoint": endpoint, "params": params})
+        return {"success": True, "cursor": None, "data": []}
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    markets = exchange.fetch_markets(
+        {
+            "limit": 250,
+            "active": False,
+            "marketVariant": "SPORTS_TEAM_MATCH",
+            "sort": "VOLUME_TOTAL_DESC",
+            "tagIds": "1,2",
+            "hasActiveRewards": True,
+        }
+    )
+
+    assert markets == []
+    assert captured["endpoint"] == "/v1/markets"
+    assert captured["params"] == {
+        "first": 100,
+        "marketVariant": "SPORTS_TEAM_MATCH",
+        "sort": "VOLUME_TOTAL_DESC",
+        "tagIds": "1,2",
+        "hasActiveRewards": True,
+    }
+
+
+def test_search_markets_expands_category_markets_before_direct_hits(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        assert endpoint == "/v1/search"
+        assert params["query"] == "2026 fifa world cup winner"
+        assert params["limit"] == "25"
+        return {
+            "success": True,
+            "data": {
+                "categories": [
+                    {
+                        "slug": "2026-fifa-world-cup-winner",
+                        "markets": [
+                            {
+                                "id": 1518,
+                                "question": "Will Spain win the 2026 FIFA World Cup?",
+                                "tradingStatus": "OPEN",
+                                "status": "REGISTERED",
+                                "outcomes": [{"name": "Yes", "onChainId": "111"}],
+                            }
+                        ],
+                    }
+                ],
+                "markets": [
+                    {
+                        "id": 1518,
+                        "question": "Duplicate direct hit",
+                        "tradingStatus": "OPEN",
+                        "status": "REGISTERED",
+                        "outcomes": [{"name": "Yes", "onChainId": "111"}],
+                    },
+                    {
+                        "id": 440853,
+                        "question": "Will a first-time winner win the World Cup?",
+                        "tradingStatus": "OPEN",
+                        "status": "REGISTERED",
+                        "outcomes": [{"name": "Yes", "onChainId": "333"}],
+                    },
+                ],
+            },
+        }
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    markets = exchange.search_markets("2026 fifa world cup winner")
+
+    assert [market.id for market in markets] == ["1518", "440853"]
+    assert markets[0].question == "Will Spain win the 2026 FIFA World Cup?"
+
+
+def test_fetch_markets_by_slug_falls_back_when_search_fails(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        if endpoint == "/v1/categories/not-a-category":
+            raise ExchangeError("not found")
+        if endpoint == "/v1/search":
+            raise ExchangeError("search unavailable")
+        if endpoint == "/v1/markets":
+            return {
+                "success": True,
+                "cursor": None,
+                "data": [
+                    {
+                        "id": 1,
+                        "question": "Will a not category market resolve?",
+                        "tradingStatus": "OPEN",
+                        "status": "REGISTERED",
+                        "outcomes": [{"name": "Yes", "onChainId": "111"}],
+                    }
+                ],
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    markets = exchange.fetch_markets_by_slug("not-a-category")
+
+    assert [market.id for market in markets] == ["1"]
+
+
+def test_get_orderbook_normalizes_tuples_and_inverts_no_token(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+    exchange._token_to_market["no-token"] = "1518"
+    exchange._token_to_index["no-token"] = 1
+    exchange._market_decimal_precision["1518"] = 3
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        assert endpoint == "/v1/markets/1518/orderbook"
+        return {
+            "success": True,
+            "data": {
+                "marketId": 1518,
+                "updateTimestampMs": 123456,
+                "bids": [[0.14, 100.0]],
+                "asks": [[0.141, 200.0]],
+            },
+        }
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    orderbook = exchange.get_orderbook("no-token")
+
+    assert orderbook["market_id"] == "1518"
+    assert orderbook["timestamp"] == 123456
+    assert orderbook["bids"] == [{"price": "0.859", "size": "200.0"}]
+    assert orderbook["asks"] == [{"price": "0.86", "size": "100.0"}]
+
+
+def test_create_order_options_passthrough_for_market():
+    data = {"pricePerShare": "100000000000000000", "strategy": "MARKET", "order": {}}
+
+    PredictFun._apply_create_order_options(
+        data,
+        {
+            "post_only": True,
+            "fill_or_kill": False,
+            "reserved_balance_policy": "SKIP_RESERVED_BALANCE_CHECKS",
+            "is_min_amount_out": True,
+            "self_trade_prevention": "CANCEL_BOTH",
+        },
+    )
+
+    assert data["isPostOnly"] is True
+    assert data["isFillOrKill"] is False
+    assert data["reservedBalancePolicy"] == "SKIP_RESERVED_BALANCE_CHECKS"
+    assert data["isMinAmountOut"] is True
+    assert data["selfTradePrevention"] == "CANCEL_BOTH"
+
+
+def test_create_order_options_reject_reserved_policy_on_limit():
+    data = {"pricePerShare": "100000000000000000", "strategy": "LIMIT", "order": {}}
+
+    with pytest.raises(InvalidOrder, match="reservedBalancePolicy"):
+        PredictFun._apply_create_order_options(
+            data,
+            {"reserved_balance_policy": "SKIP_RESERVED_BALANCE_CHECKS"},
+        )
+
+
+def test_order_strategy_requires_explicit_market_opt_in():
+    with pytest.raises(InvalidOrder, match="allow_market_order"):
+        PredictFun._normalize_order_strategy({"strategy": "MARKET"})
+
+    assert (
+        PredictFun._normalize_order_strategy({"strategy": "MARKET", "allow_market_order": True})
+        == "MARKET"
+    )
+    assert PredictFun._normalize_order_strategy({}) == "LIMIT"
+
+
+def test_extract_created_order_id_prefers_cancelable_order_id():
+    assert (
+        PredictFun._extract_created_order_id(
+            {"orderId": "123", "orderHash": "0xabc", "hash": "0xdef"}
+        )
+        == "123"
+    )
+    assert PredictFun._extract_created_order_id({"orderHash": "0xabc"}) == "0xabc"
+
+
+def test_fetch_open_orders_filters_market_id_client_side(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+    exchange._authenticated = True
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        assert endpoint == "/v1/orders"
+        assert params["marketId"] == "1519"
+        return {
+            "success": True,
+            "data": [
+                {
+                    "id": "1",
+                    "marketId": 1519,
+                    "status": "OPEN",
+                    "side": "buy",
+                    "amount": "100000000000000000000",
+                    "price": "0.1",
+                },
+                {
+                    "id": "2",
+                    "marketId": 1523,
+                    "status": "OPEN",
+                    "side": "buy",
+                    "amount": "100000000000000000000",
+                    "price": "0.1",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    orders = exchange.fetch_open_orders(market_id="1519")
+
+    assert [order.id for order in orders] == ["1"]
+
+
+def test_fetch_orders_forwards_history_filters(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+    exchange._authenticated = True
+    captured = {}
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        captured.update(
+            {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params,
+                "require_auth": require_auth,
+            }
+        )
+        return {
+            "success": True,
+            "data": [
+                {
+                    "id": "1",
+                    "marketId": 1519,
+                    "status": "FILLED",
+                    "side": "buy",
+                    "amount": "100000000000000000000",
+                    "amountFilled": "100000000000000000000",
+                    "price": "0.1",
+                },
+                {
+                    "id": "2",
+                    "marketId": 1523,
+                    "status": "FILLED",
+                    "side": "buy",
+                    "amount": "100000000000000000000",
+                    "amountFilled": "100000000000000000000",
+                    "price": "0.1",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    orders = exchange.fetch_orders(
+        market_id="1519",
+        status=OrderStatus.FILLED,
+        limit=25,
+        params={"after": "cursor-1"},
+    )
+
+    assert [order.id for order in orders] == ["1"]
+    assert captured == {
+        "method": "GET",
+        "endpoint": "/v1/orders",
+        "params": {
+            "after": "cursor-1",
+            "first": 25,
+            "status": "FILLED",
+            "marketId": "1519",
+        },
+        "require_auth": True,
+    }
+
+
+def test_fetch_order_matches_forwards_filters(monkeypatch):
+    exchange = PredictFun({"api_key": "test"})
+    captured = {}
+
+    def fake_request(method, endpoint, params=None, data=None, require_auth=False):
+        captured.update(
+            {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params,
+                "require_auth": require_auth,
+            }
+        )
+        return {
+            "success": True,
+            "data": [{"transactionHash": "0xabc", "executedAt": "2026-06-17T00:00:00Z"}],
+        }
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    matches = exchange.fetch_order_matches(
+        market_id="1519",
+        signer_address="0x123",
+        limit=20,
+        params={"isSignerMaker": True},
+    )
+
+    assert matches == [{"transactionHash": "0xabc", "executedAt": "2026-06-17T00:00:00Z"}]
+    assert captured == {
+        "method": "GET",
+        "endpoint": "/v1/orders/matches",
+        "params": {
+            "isSignerMaker": True,
+            "first": 20,
+            "marketId": "1519",
+            "signerAddress": "0x123",
+        },
+        "require_auth": False,
+    }


### PR DESCRIPTION
## Summary
- Update the Predict.fun driver for the current API market/order shapes, including search, market filters, token metadata, orderbook normalization, and position valuation fallbacks.
- Add safer order creation handling: explicit opt-in for MARKET orders, validated optional order fields, and LIMIT-order rejection for reserved balance policy.
- Add order history and match-event fetchers so monitors can inspect filled/cancelled orders and raw fill events without scraping runner logs.
- Add focused Predict.fun driver tests covering parsing, filters, order options, order history, and match-event requests.

## Validation
- `uv run ruff check dr_manhattan/exchanges/predictfun.py tests/test_predictfun.py`
- `uv run pytest tests/test_predictfun.py -q`

## Notes
- Scoped intentionally to `dr_manhattan/exchanges/predictfun.py` and `tests/test_predictfun.py` only. Strategy scripts, docs, and other dirty worktree files are excluded.
- Base is `main` because `origin/staging` does not exist in this repository.