### PR TITLE
Add normalized market time accessors

### DIFF
--- a/dr_manhattan/base/exchange.py
+++ b/dr_manhattan/base/exchange.py
@@ -353,9 +353,8 @@ class Exchange(ABC):
             if direction and parsed_direction != direction.lower():
                 continue
 
-            # Estimate expiry time from close_time
-            # For hourly markets, close_time is typically the settlement time
-            expiry = market.close_time if market.close_time else datetime.now() + timedelta(hours=1)
+            # For hourly markets, end_time is typically the settlement time.
+            expiry = market.end_time if market.end_time else datetime.now() + timedelta(hours=1)
 
             crypto_market = CryptoHourlyMarket(
                 token_symbol=parsed_token,

--- a/dr_manhattan/exchanges/limitless.py
+++ b/dr_manhattan/exchanges/limitless.py
@@ -24,7 +24,7 @@ from ..base.errors import (
     RateLimitError,
 )
 from ..base.exchange import Exchange
-from ..models.market import Market
+from ..models.market import Market, parse_market_datetime
 from ..models.order import Order, OrderSide, OrderStatus, OrderTimeInForce
 from ..models.position import Position
 from .limitless_ws import (
@@ -47,6 +47,41 @@ __all__ = [
     "PositionUpdate",
     "Trade",
 ]
+
+LIMITLESS_START_TIME_KEYS = (
+    "startAt",
+    "start_at",
+    "startTime",
+    "eventStartTime",
+    "gameStartTime",
+    "scheduledTime",
+)
+
+LIMITLESS_END_TIME_KEYS = (
+    "expirationTimestamp",
+    "deadline",
+    "closeDate",
+    "expirationDate",
+    "endDate",
+    "expiresAt",
+)
+
+
+def _first_present(data: Dict[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _add_normalized_market_times(metadata: Dict[str, Any], source: Dict[str, Any]) -> None:
+    start_time = _first_present(source, LIMITLESS_START_TIME_KEYS)
+    end_time = _first_present(source, LIMITLESS_END_TIME_KEYS)
+    if start_time is not None:
+        metadata["start_time"] = start_time
+    if end_time is not None:
+        metadata["end_time"] = end_time
 
 
 @dataclass
@@ -414,10 +449,8 @@ class Limitless(Exchange):
         token_ids = [yes_token, no_token] if yes_token and no_token else []
 
         # Parse close time
-        close_time = None
-        deadline = data.get("deadline") or data.get("expirationDate")
-        if deadline:
-            close_time = self._parse_datetime(deadline)
+        end_time_value = _first_present(data, LIMITLESS_END_TIME_KEYS)
+        close_time = parse_market_datetime(end_time_value)
 
         # Volume
         volume = float(data.get("volumeFormatted") or data.get("volume") or 0)
@@ -433,6 +466,7 @@ class Limitless(Exchange):
             "minimum_tick_size": 0.001,
             "closed": data.get("status", "").lower() in ("resolved", "closed"),
         }
+        _add_normalized_market_times(metadata, data)
 
         return Market(
             id=title,
@@ -483,10 +517,8 @@ class Limitless(Exchange):
                 prices["No"] = no_price / 100 if no_price > 1 else no_price
 
         # Parse close time
-        close_time = None
-        deadline = data.get("deadline") or data.get("closeDate") or data.get("expirationDate")
-        if deadline:
-            close_time = self._parse_datetime(deadline)
+        end_time_value = _first_present(data, LIMITLESS_END_TIME_KEYS)
+        close_time = parse_market_datetime(end_time_value)
 
         # Volume and liquidity (use formatted values if available)
         volume_raw = data.get("volumeFormatted") or data.get("volume") or 0
@@ -506,6 +538,7 @@ class Limitless(Exchange):
             "tokens": {"Yes": yes_token_id, "No": no_token_id},
             "minimum_tick_size": tick_size,
         }
+        _add_normalized_market_times(metadata, data)
 
         # Check status
         status = data.get("status", "")
@@ -1344,21 +1377,7 @@ class Limitless(Exchange):
 
     def _parse_datetime(self, timestamp: Optional[Any]) -> Optional[datetime]:
         """Parse datetime from various formats."""
-        if not timestamp:
-            return None
-
-        if isinstance(timestamp, datetime):
-            return timestamp
-
-        try:
-            if isinstance(timestamp, (int, float)):
-                # Unix timestamp
-                return datetime.fromtimestamp(timestamp, tz=timezone.utc)
-            # ISO format string
-            ts_str = str(timestamp).replace("Z", "+00:00")
-            return datetime.fromisoformat(ts_str)
-        except (ValueError, TypeError):
-            return None
+        return parse_market_datetime(timestamp)
 
     # Search and exploration methods
 

--- a/dr_manhattan/exchanges/limitless.py
+++ b/dr_manhattan/exchanges/limitless.py
@@ -84,6 +84,23 @@ def _add_normalized_market_times(metadata: Dict[str, Any], source: Dict[str, Any
         metadata["end_time"] = end_time
 
 
+def _inherit_parent_market_time(
+    data: Dict[str, Any], parent: Dict[str, Any], keys: Sequence[str], normalized_key: str
+) -> None:
+    if _first_present(data, keys) is not None or data.get(normalized_key) not in (None, ""):
+        return
+
+    for key in keys:
+        value = parent.get(key)
+        if value not in (None, ""):
+            data[key] = value
+            return
+
+    value = parent.get(normalized_key)
+    if value not in (None, ""):
+        data[normalized_key] = value
+
+
 @dataclass
 class PricePoint:
     """Represents a single price history point"""
@@ -424,7 +441,20 @@ class Limitless(Exchange):
         # Expand nested markets
         result = []
         for nested_data in nested_markets:
-            nested_market = self._parse_nested_market(nested_data, slug)
+            nested_with_parent_times = dict(nested_data)
+            _inherit_parent_market_time(
+                nested_with_parent_times,
+                market.metadata,
+                LIMITLESS_START_TIME_KEYS,
+                "start_time",
+            )
+            _inherit_parent_market_time(
+                nested_with_parent_times,
+                market.metadata,
+                LIMITLESS_END_TIME_KEYS,
+                "end_time",
+            )
+            nested_market = self._parse_nested_market(nested_with_parent_times, slug)
             result.append(nested_market)
 
         return result
@@ -449,7 +479,7 @@ class Limitless(Exchange):
         token_ids = [yes_token, no_token] if yes_token and no_token else []
 
         # Parse close time
-        end_time_value = _first_present(data, LIMITLESS_END_TIME_KEYS)
+        end_time_value = _first_present(data, LIMITLESS_END_TIME_KEYS) or data.get("end_time")
         close_time = parse_market_datetime(end_time_value)
 
         # Volume

--- a/dr_manhattan/exchanges/polymarket/polymarket_gamma.py
+++ b/dr_manhattan/exchanges/polymarket/polymarket_gamma.py
@@ -13,9 +13,41 @@ from ...base.errors import (
     NetworkError,
 )
 from ...models import CryptoHourlyMarket
-from ...models.market import Market
+from ...models.market import Market, parse_market_datetime
 from ...utils import setup_logger
 from .polymarket_core import PricePoint, Tag
+
+POLYMARKET_START_TIME_KEYS = (
+    "game_start_time",
+    "gameStartTime",
+    "event_start_time",
+    "eventStartTime",
+    "scheduledTime",
+    "startAt",
+)
+
+POLYMARKET_END_TIME_KEYS = (
+    "endDate",
+    "endDateIso",
+    "end_date_iso",
+)
+
+
+def _first_present(data: Dict[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _add_normalized_market_times(metadata: Dict[str, Any], source: Dict[str, Any]) -> None:
+    start_time = _first_present(source, POLYMARKET_START_TIME_KEYS)
+    end_time = _first_present(source, POLYMARKET_END_TIME_KEYS)
+    if start_time is not None:
+        metadata["start_time"] = start_time
+    if end_time is not None:
+        metadata["end_time"] = end_time
 
 
 class PolymarketGamma:
@@ -551,14 +583,15 @@ class PolymarketGamma:
                 continue
 
             # Check expiry time filtering based on is_active and is_expired parameters
-            if market.close_time:
+            market_end_time = market.end_time
+            if market_end_time:
                 # Handle timezone-aware datetime
-                if market.close_time.tzinfo is not None:
+                if market_end_time.tzinfo is not None:
                     now = datetime.now(timezone.utc)
                 else:
                     now = datetime.now()
 
-                time_until_expiry = (market.close_time - now).total_seconds()
+                time_until_expiry = (market_end_time - now).total_seconds()
 
                 # Apply is_expired filter
                 if is_expired:
@@ -586,9 +619,7 @@ class PolymarketGamma:
                 if token_symbol and parsed_token != self.normalize_token(token_symbol):
                     continue
 
-                expiry = (
-                    market.close_time if market.close_time else datetime.now() + timedelta(hours=1)
-                )
+                expiry = market.end_time if market.end_time else datetime.now() + timedelta(hours=1)
 
                 crypto_market = CryptoHourlyMarket(
                     token_symbol=parsed_token,
@@ -614,9 +645,7 @@ class PolymarketGamma:
                 if token_symbol and parsed_token != self.normalize_token(token_symbol):
                     continue
 
-                expiry = (
-                    market.close_time if market.close_time else datetime.now() + timedelta(hours=1)
-                )
+                expiry = market.end_time if market.end_time else datetime.now() + timedelta(hours=1)
 
                 crypto_market = CryptoHourlyMarket(
                     token_symbol=parsed_token,
@@ -675,12 +704,13 @@ class PolymarketGamma:
                 "condition_id": condition_id,
                 "minimum_tick_size": minimum_tick_size,
             }
+            _add_normalized_market_times(metadata, data)
 
             return Market(
                 id=condition_id,
                 question=question,
                 outcomes=outcomes if outcomes else ["Yes", "No"],
-                close_time=None,  # Can parse if needed
+                close_time=parse_market_datetime(metadata.get("end_time")),
                 volume=0,  # Not in sampling-markets
                 liquidity=0,  # Not in sampling-markets
                 prices=prices,
@@ -732,12 +762,13 @@ class PolymarketGamma:
                 "condition_id": condition_id,
                 "minimum_tick_size": minimum_tick_size,
             }
+            _add_normalized_market_times(metadata, data)
 
             return Market(
                 id=condition_id,
                 question="",  # CLOB API doesn't include question text
                 outcomes=outcomes if outcomes else ["Yes", "No"],
-                close_time=None,  # CLOB API doesn't include end date
+                close_time=parse_market_datetime(metadata.get("end_time")),
                 volume=0,  # CLOB API doesn't include volume
                 liquidity=0,  # CLOB API doesn't include liquidity
                 prices=prices,
@@ -802,8 +833,8 @@ class PolymarketGamma:
                 except (ValueError, TypeError):
                     pass
 
-        # Parse close time - check both endDate and closed status
-        close_time = self._parse_datetime(data.get("endDate"))
+        # Parse close time - check both endDate and CLOB-compatible end fields
+        close_time = parse_market_datetime(_first_present(data, POLYMARKET_END_TIME_KEYS))
 
         # Use volumeNum if available, fallback to volume
         volume = float(data.get("volumeNum", data.get("volume", 0)))
@@ -812,6 +843,7 @@ class PolymarketGamma:
         # Try to extract token IDs from various possible fields
         # Gamma API sometimes includes these in the response
         metadata = dict(data)
+        _add_normalized_market_times(metadata, data)
 
         # Set match_id from groupItemTitle for cross-exchange matching
         if "groupItemTitle" in data:

--- a/dr_manhattan/exchanges/polymarket/polymarket_gamma.py
+++ b/dr_manhattan/exchanges/polymarket/polymarket_gamma.py
@@ -30,6 +30,7 @@ POLYMARKET_END_TIME_KEYS = (
     "endDate",
     "endDateIso",
     "end_date_iso",
+    "end_date",
 )
 
 
@@ -48,6 +49,24 @@ def _add_normalized_market_times(metadata: Dict[str, Any], source: Dict[str, Any
         metadata["start_time"] = start_time
     if end_time is not None:
         metadata["end_time"] = end_time
+
+
+def _extract_token_ids_from_tokens(tokens: Any) -> list[str]:
+    if isinstance(tokens, str):
+        try:
+            tokens = json.loads(tokens)
+        except (json.JSONDecodeError, TypeError):
+            return []
+
+    if not isinstance(tokens, list):
+        return []
+
+    token_ids = []
+    for token in tokens:
+        token_id = token.get("token_id") if isinstance(token, dict) else token
+        if token_id:
+            token_ids.append(str(token_id))
+    return token_ids
 
 
 class PolymarketGamma:
@@ -850,7 +869,9 @@ class PolymarketGamma:
             metadata["match_id"] = data["groupItemTitle"]
 
         if "tokens" in data and data["tokens"]:
-            metadata["clobTokenIds"] = data["tokens"]
+            token_ids = _extract_token_ids_from_tokens(data["tokens"])
+            if token_ids:
+                metadata["clobTokenIds"] = token_ids
         elif "clobTokenIds" not in metadata and "tokenID" in data:
             # Single token ID - might be a simplified response
             metadata["clobTokenIds"] = [data["tokenID"]]

--- a/dr_manhattan/exchanges/predictfun.py
+++ b/dr_manhattan/exchanges/predictfun.py
@@ -27,7 +27,7 @@ from ..base.errors import (
     RateLimitError,
 )
 from ..base.exchange import Exchange
-from ..models.market import Market
+from ..models.market import Market, parse_market_datetime
 from ..models.order import Order, OrderSide, OrderStatus
 from ..models.position import Position
 from .predictfun_ws import PredictFunUserWebSocket, PredictFunWebSocket
@@ -73,6 +73,47 @@ NO_EXPIRY_TIMESTAMP = 4102444800
 # BNB Chain RPC endpoints
 BNB_RPC_MAINNET = "https://bsc-dataseed.binance.org/"
 BNB_RPC_TESTNET = "https://data-seed-prebsc-1-s1.binance.org:8545/"
+
+PREDICTFUN_START_TIME_KEYS = (
+    "startTime",
+    "startAt",
+    "startsAt",
+    "eventStartTime",
+    "gameStartTime",
+    "scheduledTime",
+    "kickoffTime",
+)
+
+PREDICTFUN_END_TIME_KEYS = (
+    "endTime",
+    "endAt",
+    "closeTime",
+    "expirationTimestamp",
+    "expirationTime",
+    "expirationDate",
+    "expiresAt",
+    "deadline",
+    "resolutionTime",
+    "resolvedAt",
+)
+
+
+def _first_present(data: Dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _add_normalized_market_times(metadata: Dict[str, Any], source: Dict[str, Any]) -> None:
+    start_time = _first_present(source, PREDICTFUN_START_TIME_KEYS)
+    end_time = _first_present(source, PREDICTFUN_END_TIME_KEYS)
+    if start_time is not None:
+        metadata["start_time"] = start_time
+    if end_time is not None:
+        metadata["end_time"] = end_time
+
 
 # ERC-20 ABI for balanceOf, allowance, and approve
 ERC20_ABI = [
@@ -483,6 +524,8 @@ class PredictFun(Exchange):
 
         # Prices (empty by default, can be fetched from orderbook)
         prices: Dict[str, float] = {}
+        end_time_value = _first_present(data, PREDICTFUN_END_TIME_KEYS)
+        close_time = parse_market_datetime(end_time_value)
 
         metadata = {
             **data,
@@ -496,6 +539,7 @@ class PredictFun(Exchange):
             "closed": closed,
             "minimum_tick_size": tick_size,
         }
+        _add_normalized_market_times(metadata, data)
 
         # Cache token_id -> market_id and index mapping for orderbook lookups
         for idx, token_id in enumerate(token_ids):
@@ -507,7 +551,7 @@ class PredictFun(Exchange):
             id=market_id,
             question=question,
             outcomes=outcomes,
-            close_time=None,
+            close_time=close_time,
             volume=volume,
             liquidity=liquidity,
             prices=prices,
@@ -835,23 +879,34 @@ class PredictFun(Exchange):
 
         outcomes = [o.get("name", "") for o in outcomes_data] if outcomes_data else ["Yes", "No"]
         token_ids = [str(o.get("onChainId", "")) for o in outcomes_data if o.get("onChainId")]
+        decimal_precision = data.get("decimalPrecision", 2)
+        tick_size = 10 ** (-decimal_precision)
+        close_time = parse_market_datetime(_first_present(data, PREDICTFUN_END_TIME_KEYS))
+
+        metadata = {
+            **data,
+            "slug": slug,
+            "clobTokenIds": token_ids,
+            "token_ids": token_ids,
+            "isNegRisk": data.get("isNegRisk", False),
+            "isYieldBearing": data.get("isYieldBearing", True),
+            "conditionId": data.get("conditionId", ""),
+            "feeRateBps": data.get("feeRateBps", 0),
+            "minimum_tick_size": tick_size,
+        }
+        _add_normalized_market_times(metadata, data)
 
         return Market(
             id=market_id,
             question=title,
             outcomes=outcomes,
-            description=data.get("description", ""),
+            close_time=close_time,
             volume=data.get("volume", 0),
             liquidity=data.get("liquidity", 0),
-            metadata={
-                "slug": slug,
-                "clobTokenIds": token_ids,
-                "token_ids": token_ids,
-                "isNegRisk": data.get("isNegRisk", False),
-                "isYieldBearing": data.get("isYieldBearing", True),
-                "conditionId": data.get("conditionId", ""),
-                "feeRateBps": data.get("feeRateBps", 0),
-            },
+            prices={},
+            metadata=metadata,
+            tick_size=tick_size,
+            description=data.get("description", ""),
         )
 
     def _search_markets_by_keywords(self, slug: str) -> List[Market]:

--- a/dr_manhattan/models/__init__.py
+++ b/dr_manhattan/models/__init__.py
@@ -1,5 +1,5 @@
 from .crypto_hourly import CryptoHourlyMarket
-from .market import ExchangeOutcomeRef, Market, OutcomeRef, OutcomeToken
+from .market import ExchangeOutcomeRef, Market, OutcomeRef, OutcomeToken, parse_market_datetime
 from .nav import NAV, PositionBreakdown
 from .order import Order, OrderSide, OrderStatus, OrderTimeInForce
 from .orderbook import Orderbook, PriceLevel
@@ -7,6 +7,7 @@ from .position import Position
 
 __all__ = [
     "Market",
+    "parse_market_datetime",
     "OutcomeRef",
     "OutcomeToken",
     "ExchangeOutcomeRef",

--- a/dr_manhattan/models/market.py
+++ b/dr_manhattan/models/market.py
@@ -64,6 +64,27 @@ DATE_FORMATS = (
     "%B %d %Y",
 )
 
+EPOCH_MILLISECONDS_THRESHOLD = 10_000_000_000
+
+
+def _datetime_from_epoch(value: float) -> Optional[datetime]:
+    if value <= 0:
+        return None
+
+    # Present-day exchange APIs use 13-digit millisecond epochs; a seconds epoch
+    # above this threshold would be year 2286+, outside supported market windows.
+    timestamp = value / 1000 if value > EPOCH_MILLISECONDS_THRESHOLD else value
+    try:
+        return datetime.fromtimestamp(timestamp, timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
 
 def parse_market_datetime(value: Any) -> Optional[datetime]:
     """Parse exchange timestamp shapes into a datetime."""
@@ -71,11 +92,13 @@ def parse_market_datetime(value: Any) -> Optional[datetime]:
         return None
 
     if isinstance(value, datetime):
-        return value
+        return _as_utc_datetime(value)
+
+    if isinstance(value, bool):
+        return None
 
     if isinstance(value, (int, float)):
-        timestamp = value / 1000 if value > 10_000_000_000 else value
-        return datetime.fromtimestamp(timestamp, timezone.utc)
+        return _datetime_from_epoch(value)
 
     if isinstance(value, str):
         stripped = value.strip()
@@ -88,17 +111,16 @@ def parse_market_datetime(value: Any) -> Optional[datetime]:
             timestamp = None
 
         if timestamp is not None:
-            timestamp = timestamp / 1000 if timestamp > 10_000_000_000 else timestamp
-            return datetime.fromtimestamp(timestamp, timezone.utc)
+            return _datetime_from_epoch(timestamp)
 
         try:
-            return datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+            return _as_utc_datetime(datetime.fromisoformat(stripped.replace("Z", "+00:00")))
         except ValueError:
             pass
 
         for date_format in DATE_FORMATS:
             try:
-                return datetime.strptime(stripped, date_format)
+                return _as_utc_datetime(datetime.strptime(stripped, date_format))
             except ValueError:
                 continue
 
@@ -202,7 +224,7 @@ class Market:
     def end_time(self) -> Optional[datetime]:
         """Get normalized trading close or event end time."""
         if self.close_time is not None:
-            return self.close_time
+            return _as_utc_datetime(self.close_time)
         return _metadata_datetime(self.metadata, END_TIME_METADATA_KEYS)
 
     @property
@@ -215,15 +237,24 @@ class Market:
         """Check if market is still open for trading"""
         # Check metadata for explicit closed status (e.g., Polymarket)
         if "closed" in self.metadata:
-            return not self.metadata["closed"]
+            closed = self.metadata["closed"]
+            if isinstance(closed, str):
+                closed_value = closed.strip().lower()
+                if closed_value in ("true", "1", "yes", "closed", "resolved"):
+                    return False
+                if closed_value in ("false", "0", "no", "open", "active"):
+                    pass
+                elif closed_value:
+                    return False
+            elif closed:
+                return False
 
         # Fallback to normalized end_time check
         end_time = self.end_time
         if not end_time:
             return True
 
-        now = datetime.now(end_time.tzinfo) if end_time.tzinfo else datetime.now()
-        return now < end_time
+        return datetime.now(timezone.utc) < end_time
 
     @property
     def spread(self) -> Optional[float]:

--- a/dr_manhattan/models/market.py
+++ b/dr_manhattan/models/market.py
@@ -1,11 +1,105 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 # Readable market ID as a path-like list:
 # - ["61"] for simple ID (Opinion)
 # - ["fed-decision-in-january", "No change"] for hierarchical (Polymarket)
 ReadableMarketId = List[str]
+
+START_TIME_METADATA_KEYS = (
+    "start_time",
+    "startTime",
+    "startAt",
+    "start_at",
+    "startDate",
+    "start_date",
+    "startDateIso",
+    "scheduledTime",
+    "scheduled_time",
+    "kickoff",
+    "kickoffTime",
+    "kickoff_time",
+    "gameStart",
+    "game_start",
+)
+
+END_TIME_METADATA_KEYS = (
+    "end_time",
+    "endTime",
+    "endAt",
+    "end_at",
+    "endDate",
+    "end_date",
+    "endDateIso",
+    "closeTime",
+    "close_time",
+    "closedAt",
+    "closed_at",
+    "expirationDate",
+    "expirationTimestamp",
+    "expiresAt",
+    "expiry",
+    "deadline",
+    "resolvedAt",
+    "resolutionTime",
+)
+
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%b %d, %Y",
+    "%B %d, %Y",
+    "%b %d %Y",
+    "%B %d %Y",
+)
+
+
+def _parse_market_datetime(value: Any) -> Optional[datetime]:
+    """Parse exchange timestamp shapes into a datetime."""
+    if value is None or value == "":
+        return None
+
+    if isinstance(value, datetime):
+        return value
+
+    if isinstance(value, (int, float)):
+        timestamp = value / 1000 if value > 10_000_000_000 else value
+        return datetime.fromtimestamp(timestamp, timezone.utc)
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+
+        try:
+            timestamp = float(stripped)
+        except ValueError:
+            timestamp = None
+
+        if timestamp is not None:
+            timestamp = timestamp / 1000 if timestamp > 10_000_000_000 else timestamp
+            return datetime.fromtimestamp(timestamp, timezone.utc)
+
+        try:
+            return datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+
+        for date_format in DATE_FORMATS:
+            try:
+                return datetime.strptime(stripped, date_format)
+            except ValueError:
+                continue
+
+    return None
+
+
+def _metadata_datetime(metadata: Dict[str, Any], keys: tuple[str, ...]) -> Optional[datetime]:
+    for key in keys:
+        parsed = _parse_market_datetime(metadata.get(key))
+        if parsed is not None:
+            return parsed
+    return None
 
 
 @dataclass
@@ -89,16 +183,36 @@ class Market:
         return len(self.outcomes) == 2
 
     @property
+    def start_time(self) -> Optional[datetime]:
+        """Get normalized event start time from exchange metadata."""
+        return _metadata_datetime(self.metadata, START_TIME_METADATA_KEYS)
+
+    @property
+    def end_time(self) -> Optional[datetime]:
+        """Get normalized trading close or event end time."""
+        if self.close_time is not None:
+            return self.close_time
+        return _metadata_datetime(self.metadata, END_TIME_METADATA_KEYS)
+
+    @property
+    def event_time(self) -> Optional[datetime]:
+        """Get the best available timestamp for scheduling around this market."""
+        return self.start_time or self.end_time
+
+    @property
     def is_open(self) -> bool:
         """Check if market is still open for trading"""
         # Check metadata for explicit closed status (e.g., Polymarket)
         if "closed" in self.metadata:
             return not self.metadata["closed"]
 
-        # Fallback to close_time check
-        if not self.close_time:
+        # Fallback to normalized end_time check
+        end_time = self.end_time
+        if not end_time:
             return True
-        return datetime.now() < self.close_time
+
+        now = datetime.now(end_time.tzinfo) if end_time.tzinfo else datetime.now()
+        return now < end_time
 
     @property
     def spread(self) -> Optional[float]:

--- a/dr_manhattan/models/market.py
+++ b/dr_manhattan/models/market.py
@@ -9,38 +9,49 @@ ReadableMarketId = List[str]
 
 START_TIME_METADATA_KEYS = (
     "start_time",
+    "event_start_time",
+    "eventStartTime",
+    "game_start_time",
+    "gameStartTime",
+    "match_start_time",
+    "matchStartTime",
     "startTime",
     "startAt",
     "start_at",
-    "startDate",
-    "start_date",
-    "startDateIso",
+    "startsAt",
+    "starts_at",
     "scheduledTime",
     "scheduled_time",
     "kickoff",
     "kickoffTime",
     "kickoff_time",
+    "kickoffAt",
+    "kickoff_at",
     "gameStart",
     "game_start",
 )
 
 END_TIME_METADATA_KEYS = (
     "end_time",
+    "event_end_time",
+    "eventEndTime",
     "endTime",
     "endAt",
     "end_at",
-    "endDate",
-    "end_date",
-    "endDateIso",
     "closeTime",
     "close_time",
-    "closedAt",
-    "closed_at",
-    "expirationDate",
     "expirationTimestamp",
+    "expirationTime",
     "expiresAt",
     "expiry",
     "deadline",
+    "endDate",
+    "end_date",
+    "endDateIso",
+    "end_date_iso",
+    "closedAt",
+    "closed_at",
+    "expirationDate",
     "resolvedAt",
     "resolutionTime",
 )
@@ -54,7 +65,7 @@ DATE_FORMATS = (
 )
 
 
-def _parse_market_datetime(value: Any) -> Optional[datetime]:
+def parse_market_datetime(value: Any) -> Optional[datetime]:
     """Parse exchange timestamp shapes into a datetime."""
     if value is None or value == "":
         return None
@@ -96,7 +107,7 @@ def _parse_market_datetime(value: Any) -> Optional[datetime]:
 
 def _metadata_datetime(metadata: Dict[str, Any], keys: tuple[str, ...]) -> Optional[datetime]:
     for key in keys:
-        parsed = _parse_market_datetime(metadata.get(key))
+        parsed = parse_market_datetime(metadata.get(key))
         if parsed is not None:
             return parsed
     return None

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -153,6 +153,37 @@ class TestLimitlessMarketParsing:
         assert market.end_time == datetime.fromtimestamp(1782144000, timezone.utc)
         assert market.close_time == market.end_time
 
+    def test_fetch_markets_by_slug_inherits_parent_times_for_nested_markets(self):
+        """Test expanded nested markets inherit parent timing when child timing is absent."""
+        exchange = Limitless({})
+
+        parent_data = {
+            "slug": "world-cup-event",
+            "title": "World Cup event",
+            "tokens": {"yes": "parent_yes", "no": "parent_no"},
+            "startAt": "2026-06-21T16:00:00Z",
+            "expirationTimestamp": 1782144000000,
+            "status": "active",
+            "markets": [
+                {
+                    "title": "Team A",
+                    "prices": [65, 35],
+                    "tokens": {"yes": "yes_token", "no": "no_token"},
+                    "status": "active",
+                }
+            ],
+        }
+
+        with patch.object(
+            exchange, "fetch_market", return_value=exchange._parse_market(parent_data)
+        ):
+            markets = exchange.fetch_markets_by_slug("world-cup-event")
+
+        assert len(markets) == 1
+        assert markets[0].start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+        assert markets[0].end_time == datetime.fromtimestamp(1782144000, timezone.utc)
+        assert markets[0].close_time == markets[0].end_time
+
 
 class TestLimitlessOrderParsing:
     """Test order parsing logic."""

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -1,5 +1,6 @@
 """Tests for Limitless exchange implementation."""
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -77,7 +78,9 @@ class TestLimitlessMarketParsing:
             "noPrice": 0.35,
             "volume": 10000.0,
             "liquidity": 5000.0,
-            "deadline": 1735689600,
+            "startAt": "2026-06-21T13:12:02.020Z",
+            "expirationDate": "Jun 21, 2026",
+            "expirationTimestamp": 1782049380000,
             "status": "active",
         }
 
@@ -93,6 +96,9 @@ class TestLimitlessMarketParsing:
         assert market.metadata["clobTokenIds"] == ["token_yes_123", "token_no_456"]
         assert market.metadata["tokens"]["Yes"] == "token_yes_123"
         assert market.metadata["tokens"]["No"] == "token_no_456"
+        assert market.start_time == datetime(2026, 6, 21, 13, 12, 2, 20000, timezone.utc)
+        assert market.end_time == datetime.fromtimestamp(1782049380, timezone.utc)
+        assert market.close_time == market.end_time
 
     def test_parse_market_with_nested_prices(self):
         """Test parsing market with nested price structure."""
@@ -127,6 +133,25 @@ class TestLimitlessMarketParsing:
         market = exchange._parse_market(mock_data)
 
         assert market.metadata["closed"] is True
+
+    def test_parse_nested_market_sets_normalized_times(self):
+        """Test nested markets preserve parent event timing fields."""
+        exchange = Limitless({})
+
+        mock_data = {
+            "title": "Team A",
+            "prices": [65, 35],
+            "tokens": {"yes": "yes_token", "no": "no_token"},
+            "startAt": "2026-06-21T16:00:00Z",
+            "expirationTimestamp": 1782144000000,
+            "status": "active",
+        }
+
+        market = exchange._parse_nested_market(mock_data, "world-cup-event")
+
+        assert market.start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+        assert market.end_time == datetime.fromtimestamp(1782144000, timezone.utc)
+        assert market.close_time == market.end_time
 
 
 class TestLimitlessOrderParsing:
@@ -260,6 +285,13 @@ class TestLimitlessDatetimeParsing:
 
         dt = exchange._parse_datetime(1735689600)
         assert dt is not None
+
+    def test_parse_datetime_timestamp_milliseconds(self):
+        """Test parsing unix millisecond timestamp."""
+        exchange = Limitless({})
+
+        dt = exchange._parse_datetime(1782049380000)
+        assert dt == datetime.fromtimestamp(1782049380, timezone.utc)
 
     def test_parse_datetime_none(self):
         """Test parsing None returns None."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -171,6 +171,26 @@ class TestMarket:
 
         assert market.end_time == datetime(2026, 6, 22)
 
+    def test_market_start_time_ignores_ambiguous_start_date(self):
+        """Test generic startDate is not treated as event start time."""
+        market = Market(
+            id="m1",
+            question="Ambiguous start date?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={
+                "startDate": "2025-05-02T15:48:10.582Z",
+                "endDate": "2026-07-31T12:00:00Z",
+            },
+            tick_size=0.01,
+        )
+
+        assert market.start_time is None
+        assert market.event_time == datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
     def test_market_spread(self):
         """Test spread property"""
         # Binary market with perfect prices (sum to 1.0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -137,7 +137,7 @@ class TestMarket:
             tick_size=0.01,
         )
 
-        assert market.end_time == close_time
+        assert market.end_time == datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
 
     def test_market_is_open_uses_metadata_end_time_when_close_time_missing(self):
         """Test is_open falls back to exchange expiry metadata."""
@@ -155,6 +155,103 @@ class TestMarket:
 
         assert market.is_open is False
 
+    def test_market_is_open_checks_end_time_when_closed_is_false(self):
+        """Test explicit closed=false does not hide an expired end_time."""
+        market = Market(
+            id="m1",
+            question="Expired but not marked closed?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"closed": False, "expirationTimestamp": 1},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is False
+
+    def test_market_is_open_treats_closed_strings_as_closed(self):
+        """Test closed metadata from stringly APIs is interpreted safely."""
+        market = Market(
+            id="m1",
+            question="Closed string?",
+            outcomes=["Yes", "No"],
+            close_time=datetime(2099, 1, 1),
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"closed": "true"},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is False
+
+    def test_market_is_open_treats_false_closed_strings_as_open(self):
+        """Test false-like closed strings do not short-circuit open checks."""
+        market = Market(
+            id="m1",
+            question="Open string?",
+            outcomes=["Yes", "No"],
+            close_time=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"closed": "false"},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is True
+
+    def test_market_is_open_treats_unknown_closed_strings_as_closed(self):
+        """Test unknown closed strings fail closed for trading safety."""
+        market = Market(
+            id="m1",
+            question="Unknown closed string?",
+            outcomes=["Yes", "No"],
+            close_time=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"closed": "halted"},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is False
+
+    def test_market_is_open_treats_naive_close_time_as_utc(self):
+        """Test legacy naive close_time values still compare safely."""
+        market = Market(
+            id="m1",
+            question="Naive close time?",
+            outcomes=["Yes", "No"],
+            close_time=datetime(2000, 1, 1),
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is False
+
+    def test_market_time_accessors_ignore_zero_bool_and_overflow_timestamps(self):
+        """Test invalid timestamp-like values are treated as unknown."""
+        for raw_value in (0, "0", True, 10**30):
+            market = Market(
+                id="m1",
+                question="Invalid timestamp?",
+                outcomes=["Yes", "No"],
+                close_time=None,
+                volume=0,
+                liquidity=0,
+                prices={},
+                metadata={"expirationTimestamp": raw_value},
+                tick_size=0.01,
+            )
+
+            assert market.end_time is None
+
     def test_market_time_accessors_parse_date_strings(self):
         """Test date-only exchange metadata is parsed."""
         market = Market(
@@ -169,7 +266,39 @@ class TestMarket:
             tick_size=0.01,
         )
 
-        assert market.end_time == datetime(2026, 6, 22)
+        assert market.end_time == datetime(2026, 6, 22, tzinfo=timezone.utc)
+
+    def test_market_time_accessors_normalize_naive_datetimes_to_utc(self):
+        """Test datetime metadata is always normalized to UTC."""
+        market = Market(
+            id="m1",
+            question="Naive datetime?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"start_time": datetime(2026, 6, 22, 12, 30)},
+            tick_size=0.01,
+        )
+
+        assert market.start_time == datetime(2026, 6, 22, 12, 30, tzinfo=timezone.utc)
+
+    def test_market_time_accessors_parse_iso_date_as_utc(self):
+        """Test ISO date-only metadata is parsed as UTC midnight."""
+        market = Market(
+            id="m1",
+            question="ISO date?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"end_time": "2026-06-22"},
+            tick_size=0.01,
+        )
+
+        assert market.end_time == datetime(2026, 6, 22, tzinfo=timezone.utc)
 
     def test_market_start_time_ignores_ambiguous_start_date(self):
         """Test generic startDate is not treated as event start time."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 """Tests for data models"""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dr_manhattan.models.market import Market
 from dr_manhattan.models.order import Order, OrderSide, OrderStatus, OrderTimeInForce
@@ -100,6 +100,76 @@ class TestMarket:
             tick_size=0.01,
         )
         assert no_close_time_market.is_open is True
+
+    def test_market_time_accessors_parse_exchange_metadata(self):
+        """Test normalized market timing accessors parse common exchange metadata."""
+        market = Market(
+            id="m1",
+            question="World Cup match?",
+            outcomes=["Team A", "Team B"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={
+                "startAt": "2026-06-21T16:00:00Z",
+                "expirationTimestamp": 1782144000000,
+            },
+            tick_size=0.01,
+        )
+
+        assert market.start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+        assert market.end_time == datetime.fromtimestamp(1782144000, timezone.utc)
+        assert market.event_time == market.start_time
+
+    def test_market_end_time_prefers_close_time(self):
+        """Test close_time remains the canonical end_time when present."""
+        close_time = datetime(2026, 1, 1, 12, 0)
+        market = Market(
+            id="m1",
+            question="Close time?",
+            outcomes=["Yes", "No"],
+            close_time=close_time,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"expirationTimestamp": 1782144000000},
+            tick_size=0.01,
+        )
+
+        assert market.end_time == close_time
+
+    def test_market_is_open_uses_metadata_end_time_when_close_time_missing(self):
+        """Test is_open falls back to exchange expiry metadata."""
+        market = Market(
+            id="m1",
+            question="Expired?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"expirationTimestamp": 1},
+            tick_size=0.01,
+        )
+
+        assert market.is_open is False
+
+    def test_market_time_accessors_parse_date_strings(self):
+        """Test date-only exchange metadata is parsed."""
+        market = Market(
+            id="m1",
+            question="Date string?",
+            outcomes=["Yes", "No"],
+            close_time=None,
+            volume=0,
+            liquidity=0,
+            prices={},
+            metadata={"expirationDate": "Jun 22, 2026"},
+            tick_size=0.01,
+        )
+
+        assert market.end_time == datetime(2026, 6, 22)
 
     def test_market_spread(self):
         """Test spread property"""

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -1,5 +1,6 @@
 """Tests for Polymarket exchange implementation"""
 
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -58,6 +59,8 @@ def test_fetch_markets(mock_get):
                 "active": True,
                 "closed": False,
                 "accepting_orders": True,
+                "game_start_time": "2026-06-21T16:00:00Z",
+                "end_date_iso": "2026-06-21T18:00:00Z",
                 "minimum_tick_size": 0.01,
             }
         ]
@@ -71,6 +74,9 @@ def test_fetch_markets(mock_get):
     assert len(markets) == 1
     assert markets[0].id == "0xabc123"
     assert markets[0].prices == {"Yes": 0.6, "No": 0.4}
+    assert markets[0].start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+    assert markets[0].end_time == datetime(2026, 6, 21, 18, 0, tzinfo=timezone.utc)
+    assert markets[0].close_time == markets[0].end_time
 
 
 @patch.object(Polymarket, "fetch_token_ids", return_value=["token1", "token2"])
@@ -191,3 +197,47 @@ def test_parse_datetime():
     # Test invalid
     dt = exchange._parse_datetime("invalid")
     assert dt is None
+
+
+def test_parse_gamma_market_normalizes_event_times():
+    """Test Gamma parser normalizes endDate but does not treat startDate as kickoff."""
+    exchange = Polymarket()
+
+    market = exchange._parse_market(
+        {
+            "id": "540817",
+            "question": "New Rihanna Album before GTA VI?",
+            "outcomes": '["Yes", "No"]',
+            "outcomePrices": '["0.515", "0.485"]',
+            "startDate": "2025-05-02T15:48:10.582Z",
+            "endDate": "2026-07-31T12:00:00Z",
+            "active": True,
+            "closed": False,
+        }
+    )
+
+    assert market.start_time is None
+    assert market.end_time == datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+    assert market.event_time == market.end_time
+
+
+def test_parse_gamma_market_uses_game_start_time():
+    """Test Gamma parser maps game_start_time to normalized start_time."""
+    exchange = Polymarket()
+
+    market = exchange._parse_market(
+        {
+            "id": "sports-market",
+            "question": "World Cup: Team A vs Team B",
+            "outcomes": '["Team A", "Team B"]',
+            "outcomePrices": '["0.5", "0.5"]',
+            "startDate": "2026-06-01T00:00:00Z",
+            "game_start_time": "2026-06-21T16:00:00Z",
+            "endDate": "2026-06-22T00:00:00Z",
+            "active": True,
+            "closed": False,
+        }
+    )
+
+    assert market.start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+    assert market.end_time == datetime(2026, 6, 22, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_polymarket.py
+++ b/tests/test_polymarket.py
@@ -241,3 +241,45 @@ def test_parse_gamma_market_uses_game_start_time():
 
     assert market.start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
     assert market.end_time == datetime(2026, 6, 22, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_gamma_market_normalizes_snake_case_end_date():
+    """Test Gamma parser accepts snake_case end_date from API responses."""
+    exchange = Polymarket()
+
+    market = exchange._parse_market(
+        {
+            "id": "snake-case-end-date",
+            "question": "Snake case end date?",
+            "outcomes": '["Yes", "No"]',
+            "outcomePrices": '["0.5", "0.5"]',
+            "end_date": "2026-06-22T00:00:00Z",
+            "active": True,
+            "closed": False,
+        }
+    )
+
+    assert market.end_time == datetime(2026, 6, 22, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_gamma_market_extracts_clob_token_ids_from_token_objects():
+    """Test Gamma parser exposes clobTokenIds as strings when tokens are objects."""
+    exchange = Polymarket()
+
+    market = exchange._parse_market(
+        {
+            "id": "token-object-market",
+            "question": "Token objects?",
+            "outcomes": '["Yes", "No"]',
+            "outcomePrices": '["0.6", "0.4"]',
+            "tokens": [
+                {"token_id": "token_yes", "outcome": "Yes"},
+                {"token_id": "token_no", "outcome": "No"},
+            ],
+            "active": True,
+            "closed": False,
+        }
+    )
+
+    assert market.metadata["clobTokenIds"] == ["token_yes", "token_no"]
+    assert market.metadata["tokens"][0]["token_id"] == "token_yes"

--- a/tests/test_predictfun.py
+++ b/tests/test_predictfun.py
@@ -1,0 +1,52 @@
+"""Tests for Predict.fun exchange implementation."""
+
+from datetime import datetime, timezone
+
+from dr_manhattan.exchanges.predictfun import PredictFun
+
+
+def test_parse_market_sets_normalized_times():
+    """Test Predict.fun parser maps API time fields to Market accessors."""
+    exchange = PredictFun({})
+
+    market = exchange._parse_market(
+        {
+            "id": 483522,
+            "title": "World Cup match?",
+            "outcomes": [
+                {"name": "Team A", "onChainId": "1"},
+                {"name": "Team B", "onChainId": "2"},
+            ],
+            "startTime": "2026-06-21T16:00:00Z",
+            "expirationTimestamp": 1782144000000,
+            "status": "REGISTERED",
+            "decimalPrecision": 2,
+        }
+    )
+
+    assert market.start_time == datetime(2026, 6, 21, 16, 0, tzinfo=timezone.utc)
+    assert market.end_time == datetime.fromtimestamp(1782144000, timezone.utc)
+    assert market.close_time == market.end_time
+
+
+def test_parse_category_as_market_sets_normalized_times():
+    """Test Predict.fun category fallback builds a complete Market with timing."""
+    exchange = PredictFun({})
+
+    market = exchange._parse_category_as_market(
+        {
+            "id": 1,
+            "title": "World Cup category market?",
+            "slug": "world-cup-category",
+            "outcomes": [
+                {"name": "Yes", "onChainId": "1"},
+                {"name": "No", "onChainId": "2"},
+            ],
+            "endTime": "2026-06-22T00:00:00Z",
+            "decimalPrecision": 3,
+        }
+    )
+
+    assert market.id == "1"
+    assert market.end_time == datetime(2026, 6, 22, 0, 0, tzinfo=timezone.utc)
+    assert market.tick_size == 0.001


### PR DESCRIPTION
## Summary
- add normalized `Market.start_time`, `Market.end_time`, and `Market.event_time` accessors backed by shared timestamp parsing
- normalize active exchange timing metadata for Polymarket, Limitless, and Predict.fun while preserving raw exchange payloads
- harden `Market.is_open` so expired markets are not reported open, naive/date-only timestamps normalize to UTC, and unknown closed-status strings fail closed
- harden Polymarket Gamma parsing for `end_date` and object-shaped `tokens` arrays, and preserve parent timing when expanding Limitless nested markets

## Review / Reconciliation
- Codex review found Limitless nested markets could drop parent event timing; fixed with parent-time inheritance and regression coverage
- Claude Code review found UTC normalization and closed-string edge cases in `Market`; fixed and re-reviewed to no actionable findings
- Claude Code exchange review found missing Polymarket `end_date` support and `clobTokenIds` object-list leakage; fixed and re-reviewed to no actionable findings
- Claude cloud `ultrareview` could not launch because free ultrareviews were exhausted, so review was completed through local Claude Code file-scoped reviews

## Verification
- `uv run --python 3.13 --group dev ruff format --check dr_manhattan tests`
- `uv run --python 3.13 --group dev ruff check dr_manhattan tests`
- `uv run --python 3.13 --group dev python -m pytest` -> 273 passed, 11 skipped
- `uv run --python 3.13 --group dev python -m py_compile $(rg --files dr_manhattan -g '*.py')`
- `uv build`
- `uv run --python 3.13 --group dev twine check dist/*`
- `uv run --python 3.12 --group dev python -m pytest tests/test_models.py tests/test_limitless.py tests/test_polymarket.py tests/test_predictfun.py` -> 109 passed
- `uv run --python 3.11 --group dev python -m pytest tests/test_models.py tests/test_limitless.py tests/test_polymarket.py tests/test_predictfun.py` -> 109 passed
- live fetch smoke: Polymarket 3 markets, Limitless 3 markets, Predict.fun 3 markets with `PREDICTFUN_API_KEY` passed explicitly

Base: `main` (no `staging` branch exists on origin)