### PR TITLE
Add async runtime order hooks

### DIFF
--- a/dr_manhattan/runtime/__init__.py
+++ b/dr_manhattan/runtime/__init__.py
@@ -1,0 +1,21 @@
+"""Runtime helpers for low-latency trading workflows."""
+
+from .async_worker import AsyncWorker, OverflowPolicy, WorkerStats
+from .order_hooks import (
+    OrderDecision,
+    OrderHookPipeline,
+    OrderIntent,
+    OrderResult,
+    PostOrderDispatcher,
+)
+
+__all__ = [
+    "AsyncWorker",
+    "OverflowPolicy",
+    "WorkerStats",
+    "OrderDecision",
+    "OrderHookPipeline",
+    "OrderIntent",
+    "OrderResult",
+    "PostOrderDispatcher",
+]

--- a/dr_manhattan/runtime/async_worker.py
+++ b/dr_manhattan/runtime/async_worker.py
@@ -1,0 +1,195 @@
+"""Thread-backed worker for moving slow side effects off a hot path."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class OverflowPolicy(str, Enum):
+    """How an AsyncWorker handles submissions when its queue is full."""
+
+    DROP_NEWEST = "drop_newest"
+    DROP_OLDEST = "drop_oldest"
+    BLOCK = "block"
+    RAISE = "raise"
+
+
+@dataclass(frozen=True)
+class WorkerStats:
+    submitted: int = 0
+    processed: int = 0
+    failed: int = 0
+    dropped: int = 0
+    queue_size: int = 0
+
+
+class AsyncWorker(Generic[T]):
+    """Run blocking handlers in a background thread.
+
+    The SDK is mostly synchronous, so this class intentionally uses a thread
+    rather than requiring users to own an asyncio event loop. It is intended for
+    durable but non-critical side effects such as alerts, metrics, and SQLite
+    writes. Do not use it for checks that must approve an order before submit.
+    """
+
+    def __init__(
+        self,
+        handler: Callable[[T], None],
+        *,
+        name: str = "dr-manhattan-worker",
+        queue_size: int = 1000,
+        overflow_policy: OverflowPolicy = OverflowPolicy.DROP_NEWEST,
+        on_error: Callable[[BaseException, T], None] | None = None,
+    ) -> None:
+        if queue_size < 1:
+            raise ValueError("queue_size must be >= 1")
+        self.handler = handler
+        self.name = name
+        self.overflow_policy = overflow_policy
+        self.on_error = on_error
+        self._queue: queue.Queue[T | object] = queue.Queue(maxsize=queue_size)
+        self._sentinel = object()
+        self._lock = threading.Lock()
+        self._closed = False
+        self._thread: threading.Thread | None = None
+        self._submitted = 0
+        self._processed = 0
+        self._failed = 0
+        self._dropped = 0
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._thread = threading.Thread(target=self._run, name=self.name, daemon=True)
+            self._thread.start()
+
+    def submit(self, item: T, *, timeout: float | None = None) -> bool:
+        """Queue an item for background processing.
+
+        Returns False when the configured overflow policy drops the item or the
+        worker is already closed.
+        """
+
+        self.start()
+        with self._lock:
+            if self._closed:
+                return False
+
+        if self.overflow_policy == OverflowPolicy.BLOCK:
+            try:
+                self._queue.put(item, timeout=timeout)
+            except queue.Full:
+                self._increment_dropped()
+                return False
+            self._increment_submitted()
+            return True
+
+        try:
+            self._queue.put_nowait(item)
+        except queue.Full:
+            if self.overflow_policy == OverflowPolicy.RAISE:
+                raise
+            if self.overflow_policy == OverflowPolicy.DROP_OLDEST:
+                if not self._drop_oldest_pending():
+                    self._increment_dropped()
+                    return False
+                self._queue.put_nowait(item)
+                self._increment_submitted()
+                return True
+            self._increment_dropped()
+            return False
+
+        self._increment_submitted()
+        return True
+
+    def close(self, *, timeout: float | None = 5.0, drain: bool = True) -> None:
+        """Stop the worker.
+
+        With drain=True, all already queued items are processed before the
+        worker exits. With drain=False, queued items are discarded first.
+        """
+
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        if not drain:
+            self._drop_all_pending()
+
+        self.start()
+        self._queue.put(self._sentinel)
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    @property
+    def stats(self) -> WorkerStats:
+        with self._lock:
+            return WorkerStats(
+                submitted=self._submitted,
+                processed=self._processed,
+                failed=self._failed,
+                dropped=self._dropped,
+                queue_size=self._queue.qsize(),
+            )
+
+    def _run(self) -> None:
+        while True:
+            item = self._queue.get()
+            try:
+                if item is self._sentinel:
+                    return
+                self.handler(item)  # type: ignore[arg-type]
+                self._increment_processed()
+            except BaseException as exc:
+                self._increment_failed()
+                if item is not self._sentinel and self.on_error is not None:
+                    self.on_error(exc, item)  # type: ignore[arg-type]
+            finally:
+                self._queue.task_done()
+
+    def _drop_oldest_pending(self) -> bool:
+        try:
+            self._queue.get_nowait()
+        except queue.Empty:
+            return False
+        self._queue.task_done()
+        self._increment_dropped()
+        return True
+
+    def _drop_all_pending(self) -> None:
+        dropped = 0
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if item is not self._sentinel:
+                dropped += 1
+            self._queue.task_done()
+        if dropped:
+            self._increment_dropped(dropped)
+
+    def _increment_submitted(self) -> None:
+        with self._lock:
+            self._submitted += 1
+
+    def _increment_processed(self) -> None:
+        with self._lock:
+            self._processed += 1
+
+    def _increment_failed(self) -> None:
+        with self._lock:
+            self._failed += 1
+
+    def _increment_dropped(self, count: int = 1) -> None:
+        with self._lock:
+            self._dropped += count

--- a/dr_manhattan/runtime/order_hooks.py
+++ b/dr_manhattan/runtime/order_hooks.py
@@ -1,0 +1,205 @@
+"""Composable order hook primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from time import time_ns
+from typing import Any, Callable, Mapping, Protocol
+
+from dr_manhattan.models.order import Order, OrderSide
+
+from .async_worker import AsyncWorker, OverflowPolicy
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    market_id: str
+    outcome: str
+    side: OrderSide
+    price: float
+    size: float
+    params: Mapping[str, Any] = field(default_factory=dict)
+    venue: str | None = None
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    def with_updates(self, **updates: Any) -> "OrderIntent":
+        return replace(self, **updates)
+
+
+@dataclass(frozen=True)
+class OrderDecision:
+    allowed: bool
+    intent: OrderIntent
+    reason: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def allow(
+        cls,
+        intent: OrderIntent,
+        *,
+        reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "OrderDecision":
+        return cls(True, intent, reason=reason, metadata=metadata or {})
+
+    @classmethod
+    def reject(
+        cls,
+        intent: OrderIntent,
+        reason: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "OrderDecision":
+        return cls(False, intent, reason=reason, metadata=metadata or {})
+
+
+@dataclass(frozen=True)
+class OrderResult:
+    intent: OrderIntent
+    started_ns: int
+    finished_ns: int
+    order: Order | None = None
+    error: BaseException | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def success(
+        cls,
+        intent: OrderIntent,
+        order: Order,
+        *,
+        started_ns: int,
+        finished_ns: int | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "OrderResult":
+        return cls(
+            intent=intent,
+            order=order,
+            started_ns=started_ns,
+            finished_ns=finished_ns or time_ns(),
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        intent: OrderIntent,
+        error: BaseException,
+        *,
+        started_ns: int,
+        finished_ns: int | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "OrderResult":
+        return cls(
+            intent=intent,
+            error=error,
+            started_ns=started_ns,
+            finished_ns=finished_ns or time_ns(),
+            metadata=metadata or {},
+        )
+
+    @property
+    def succeeded(self) -> bool:
+        return self.order is not None and self.error is None
+
+    @property
+    def latency_ms(self) -> float:
+        return max(0.0, (self.finished_ns - self.started_ns) / 1_000_000)
+
+
+class PreOrderHook(Protocol):
+    def __call__(self, intent: OrderIntent) -> OrderDecision | OrderIntent | None: ...
+
+
+class PostOrderHook(Protocol):
+    def __call__(self, result: OrderResult) -> None: ...
+
+
+class PostOrderDispatcher:
+    def __init__(
+        self,
+        hooks: list[PostOrderHook] | tuple[PostOrderHook, ...],
+        *,
+        on_error: Callable[[BaseException, OrderResult, PostOrderHook], None] | None = None,
+    ) -> None:
+        self.hooks = tuple(hooks)
+        self.on_error = on_error
+
+    def __call__(self, result: OrderResult) -> None:
+        for hook in self.hooks:
+            try:
+                hook(result)
+            except BaseException as exc:
+                if self.on_error is not None:
+                    self.on_error(exc, result, hook)
+
+
+class OrderHookPipeline:
+    """Run pre-order hooks synchronously and post-order hooks optionally async."""
+
+    def __init__(
+        self,
+        *,
+        pre_order_hooks: list[PreOrderHook] | tuple[PreOrderHook, ...] = (),
+        post_order_hooks: list[PostOrderHook] | tuple[PostOrderHook, ...] = (),
+        post_order_worker: AsyncWorker[OrderResult] | None = None,
+        post_order_async: bool = False,
+        post_order_queue_size: int = 1000,
+        post_order_overflow_policy: OverflowPolicy = OverflowPolicy.DROP_NEWEST,
+        fail_closed: bool = True,
+        on_post_order_error: (
+            Callable[[BaseException, OrderResult, PostOrderHook], None] | None
+        ) = None,
+    ) -> None:
+        self.pre_order_hooks = tuple(pre_order_hooks)
+        self.dispatcher = PostOrderDispatcher(post_order_hooks, on_error=on_post_order_error)
+        if post_order_worker is None and post_order_async:
+            post_order_worker = AsyncWorker(
+                self.dispatcher,
+                name="dr-manhattan-post-order-hooks",
+                queue_size=post_order_queue_size,
+                overflow_policy=post_order_overflow_policy,
+            )
+            self._owns_post_order_worker = True
+        else:
+            self._owns_post_order_worker = False
+        self.post_order_worker = post_order_worker
+        self.fail_closed = fail_closed
+
+    def prepare(self, intent: OrderIntent) -> OrderDecision:
+        current = intent
+        for hook in self.pre_order_hooks:
+            try:
+                decision = hook(current)
+            except BaseException as exc:
+                if self.fail_closed:
+                    return OrderDecision.reject(
+                        current,
+                        "pre_order_hook_error",
+                        metadata={"hook": hook_name(hook), "error": str(exc)},
+                    )
+                continue
+            if decision is None:
+                continue
+            if isinstance(decision, OrderIntent):
+                current = decision
+                continue
+            if not decision.allowed:
+                return decision
+            current = decision.intent
+        return OrderDecision.allow(current)
+
+    def emit_result(self, result: OrderResult) -> bool:
+        if self.post_order_worker is not None:
+            return self.post_order_worker.submit(result)
+        self.dispatcher(result)
+        return True
+
+    def close(self, *, timeout: float | None = 5.0) -> None:
+        if self._owns_post_order_worker and self.post_order_worker is not None:
+            self.post_order_worker.close(timeout=timeout)
+
+
+def hook_name(hook: Any) -> str:
+    return getattr(hook, "__name__", hook.__class__.__name__)

--- a/tests/test_runtime_worker_hooks.py
+++ b/tests/test_runtime_worker_hooks.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timezone
+from threading import Event
+
+from dr_manhattan.models.order import Order, OrderSide, OrderStatus
+from dr_manhattan.runtime import (
+    AsyncWorker,
+    OrderDecision,
+    OrderHookPipeline,
+    OrderIntent,
+    OrderResult,
+    OverflowPolicy,
+)
+
+
+def test_async_worker_processes_items_and_reports_stats():
+    processed = []
+
+    worker = AsyncWorker(processed.append, queue_size=4)
+    assert worker.submit("a")
+    assert worker.submit("b")
+    worker.close()
+
+    assert processed == ["a", "b"]
+    assert worker.stats.submitted == 2
+    assert worker.stats.processed == 2
+    assert worker.stats.failed == 0
+    assert worker.stats.dropped == 0
+
+
+def test_async_worker_drop_newest_overflow_is_non_blocking():
+    entered = Event()
+    release = Event()
+    processed = []
+
+    def handler(item):
+        entered.set()
+        release.wait(timeout=1)
+        processed.append(item)
+
+    worker = AsyncWorker(handler, queue_size=1, overflow_policy=OverflowPolicy.DROP_NEWEST)
+    assert worker.submit("first")
+    assert entered.wait(timeout=1)
+    assert worker.submit("second")
+    dropped = worker.submit("third")
+
+    release.set()
+    worker.close()
+
+    assert dropped is False
+    assert processed == ["first", "second"]
+    assert worker.stats.dropped == 1
+
+
+def test_order_pipeline_runs_pre_order_hooks_synchronously():
+    intent = OrderIntent(
+        venue="predictfun",
+        market_id="123",
+        outcome="Yes",
+        side=OrderSide.BUY,
+        price=0.42,
+        size=10,
+    )
+
+    def cap_size(candidate: OrderIntent) -> OrderIntent:
+        return candidate.with_updates(size=min(candidate.size, 2.5))
+
+    def reject_low_price(candidate: OrderIntent) -> OrderDecision:
+        if candidate.price < 0.05:
+            return OrderDecision.reject(candidate, "price_below_floor")
+        return OrderDecision.allow(candidate)
+
+    pipeline = OrderHookPipeline(pre_order_hooks=[cap_size, reject_low_price])
+    decision = pipeline.prepare(intent)
+
+    assert decision.allowed is True
+    assert decision.intent.size == 2.5
+
+    rejected = pipeline.prepare(intent.with_updates(price=0.01))
+    assert rejected.allowed is False
+    assert rejected.reason == "price_below_floor"
+
+
+def test_order_pipeline_queues_post_order_hooks():
+    received = []
+    pipeline = OrderHookPipeline(
+        post_order_hooks=[lambda result: received.append(result.order.id)],
+        post_order_async=True,
+        post_order_queue_size=4,
+    )
+    intent = OrderIntent("123", "Yes", OrderSide.BUY, 0.42, 2)
+    order = sample_order()
+
+    assert pipeline.emit_result(
+        OrderResult.success(intent, order, started_ns=1_000_000, finished_ns=2_000_000)
+    )
+    pipeline.close()
+
+    assert received == ["order-1"]
+
+
+def test_order_pipeline_dispatches_post_hooks_without_failing_other_hooks():
+    errors = []
+    received = []
+    intent = OrderIntent("123", "Yes", OrderSide.BUY, 0.42, 2)
+    order = sample_order()
+    result = OrderResult.success(intent, order, started_ns=1, finished_ns=1_000_001)
+
+    def bad_hook(_result):
+        raise RuntimeError("alert backend unavailable")
+
+    def good_hook(hook_result):
+        received.append(hook_result.latency_ms)
+
+    pipeline = OrderHookPipeline(
+        post_order_hooks=[bad_hook, good_hook],
+        on_post_order_error=lambda exc, _result, hook: errors.append((str(exc), hook.__name__)),
+    )
+
+    assert pipeline.emit_result(result)
+
+    assert errors == [("alert backend unavailable", "bad_hook")]
+    assert received == [1.0]
+
+
+def sample_order() -> Order:
+    return Order(
+        id="order-1",
+        market_id="123",
+        outcome="Yes",
+        side=OrderSide.BUY,
+        price=0.42,
+        size=2,
+        filled=0,
+        status=OrderStatus.OPEN,
+        created_at=datetime.now(timezone.utc),
+    )


### PR DESCRIPTION
## Summary
- add a thread-backed `AsyncWorker` for bounded background side effects
- add order hook primitives with synchronous pre-order decisions and optional async post-order dispatch
- cover worker overflow, stats, pre-order veto/amend, and post-order hook behavior

## Verification
- `uv run pytest tests/test_runtime_worker_hooks.py -q`
- `uv run pytest -q`

Base is `main` because this public repo has no `staging` branch.