### PR TITLE
Extract Polymarket relay and SQLite event sink

### DIFF
--- a/dr_manhattan/exchanges/polymarket/polymarket_ws.py
+++ b/dr_manhattan/exchanges/polymarket/polymarket_ws.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional
 import websockets
 import websockets.exceptions
 
-from ...base.websocket import OrderBookWebSocket
+from ...base.websocket import OrderBookWebSocket, WebSocketState
 from ...models.orderbook import OrderbookManager
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ class PolymarketWebSocket(OrderBookWebSocket):
 
         # Orderbook manager
         self.orderbook_manager = OrderbookManager()
+        self._book_state: Dict[str, Dict[str, Any]] = {}
 
     @property
     def ws_url(self) -> str:
@@ -96,13 +97,22 @@ class PolymarketWebSocket(OrderBookWebSocket):
         # Mark as subscribed
         self.subscribed_assets.add(asset_id)
 
-        # Send subscription message
-        subscribe_message = {"auth": {}, "markets": [], "assets_ids": [asset_id], "type": "market"}
-
-        await self.ws.send(json.dumps(subscribe_message))
+        await self._send_subscription()
 
         if self.verbose:
             logger.debug(f"Subscribed to market/asset: {asset_id}")
+
+    async def _send_subscription(self):
+        """Send the full current asset subscription set."""
+        subscribe_message = {
+            "auth": {},
+            "markets": [],
+            "assets_ids": list(self.subscribed_assets),
+            "type": "market",
+            "custom_feature_enabled": True,
+        }
+
+        await self.ws.send(json.dumps(subscribe_message))
 
     async def _unsubscribe_orderbook(self, market_id: str):
         """
@@ -117,19 +127,14 @@ class PolymarketWebSocket(OrderBookWebSocket):
         self.subscribed_assets.discard(asset_id)
 
         # Send unsubscription (resubscribe with remaining assets)
-        subscribe_message = {
-            "auth": {},
-            "markets": [],
-            "assets_ids": list(self.subscribed_assets),
-            "type": "market",
-        }
-
-        await self.ws.send(json.dumps(subscribe_message))
+        await self._send_subscription()
 
         if self.verbose:
             logger.debug(f"Unsubscribed from market/asset: {asset_id}")
 
-    def _parse_orderbook_message(self, message: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def _parse_orderbook_message(
+        self, message: Dict[str, Any]
+    ) -> Optional[Dict[str, Any] | List[Dict[str, Any]]]:
         """
         Parse incoming WebSocket message into standardized orderbook format.
 
@@ -145,10 +150,17 @@ class PolymarketWebSocket(OrderBookWebSocket):
         """
         event_type = message.get("event_type")
 
-        if event_type == "book":
+        if event_type == "book" or (
+            event_type is None
+            and message.get("asset_id")
+            and "bids" in message
+            and "asks" in message
+        ):
             return self._parse_book_message(message)
         elif event_type == "price_change":
             return self._parse_price_change_message(message)
+        elif event_type == "best_bid_ask":
+            return self._parse_best_bid_ask_message(message)
 
         return None
 
@@ -194,6 +206,13 @@ class PolymarketWebSocket(OrderBookWebSocket):
         # Sort bids descending, asks ascending
         bids.sort(reverse=True)
         asks.sort()
+        self._book_state[asset_id] = {
+            "market_id": market_id,
+            "bids": dict(bids),
+            "asks": dict(asks),
+            "timestamp": message.get("timestamp", 0),
+            "hash": message.get("hash", ""),
+        }
 
         return {
             "market_id": market_id,
@@ -204,7 +223,7 @@ class PolymarketWebSocket(OrderBookWebSocket):
             "hash": message.get("hash", ""),
         }
 
-    def _parse_price_change_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
+    def _parse_price_change_message(self, message: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Parse price_change message (incremental updates).
 
@@ -231,41 +250,100 @@ class PolymarketWebSocket(OrderBookWebSocket):
         if not price_changes:
             return None
 
-        # Use first price change (usually one per message)
-        change = price_changes[0]
-        asset_id = change.get("asset_id", "")
+        updates = []
+        for change in price_changes:
+            asset_id = change.get("asset_id", "")
+            if not asset_id:
+                continue
+            state = self._book_state.setdefault(
+                asset_id,
+                {
+                    "market_id": market_id,
+                    "bids": {},
+                    "asks": {},
+                    "timestamp": timestamp,
+                    "hash": change.get("hash", ""),
+                },
+            )
+            state["market_id"] = market_id or state.get("market_id", asset_id)
+            state["timestamp"] = timestamp
+            state["hash"] = change.get("hash", state.get("hash", ""))
+            self._apply_price_change(state, change)
+            updates.append(self._state_orderbook(asset_id, state))
 
-        # Build orderbook from best bid/ask
-        bids = []
-        asks = []
+        return updates
 
+    def _parse_best_bid_ask_message(self, message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        market_id = message.get("market", "")
+        timestamp = message.get("timestamp", 0)
+        updates = []
+        items = message.get("price_changes") or message.get("changes") or []
+        if not items and message.get("asset_id"):
+            items = [message]
+        for item in items:
+            asset_id = item.get("asset_id", "")
+            if not asset_id or asset_id not in self._book_state:
+                continue
+            state = self._book_state[asset_id]
+            state["market_id"] = market_id or state.get("market_id", asset_id)
+            state["timestamp"] = timestamp
+            state["hash"] = item.get("hash", state.get("hash", ""))
+            self._apply_top_of_book_hint(state, item)
+            updates.append(self._state_orderbook(asset_id, state))
+        return updates
+
+    def _apply_top_of_book_hint(self, state: Dict[str, Any], item: Dict[str, Any]) -> None:
+        """Keep known depth aligned with Polymarket best_bid_ask when size is already known."""
+        for field, side in (("best_bid", "bids"), ("best_ask", "asks")):
+            value = item.get(field)
+            if value is None:
+                continue
+            try:
+                price = float(value)
+            except (TypeError, ValueError):
+                continue
+            if price <= 0 or price in state[side]:
+                continue
+            levels = state[side]
+            if not levels:
+                continue
+            if side == "bids":
+                stale_prices = [existing for existing in levels if existing > price]
+            else:
+                stale_prices = [existing for existing in levels if existing < price]
+            for existing in stale_prices:
+                levels.pop(existing, None)
+
+    def _apply_price_change(self, state: Dict[str, Any], change: Dict[str, Any]) -> None:
         try:
-            best_bid = change.get("best_bid")
-            best_ask = change.get("best_ask")
+            price = float(change.get("price", 0))
+            size = float(change.get("size", 0))
+        except (TypeError, ValueError):
+            return
+        if price <= 0:
+            return
+        side = str(change.get("side", "")).upper()
+        if side == "BUY":
+            levels = state["bids"]
+        elif side == "SELL":
+            levels = state["asks"]
+        else:
+            return
+        if size > 0:
+            levels[price] = size
+        else:
+            levels.pop(price, None)
 
-            if best_bid:
-                price = float(best_bid)
-                if price > 0:
-                    # We don't get size from price_change, use placeholder
-                    bids.append((price, 0.0))
-
-            if best_ask:
-                price = float(best_ask)
-                if price > 0:
-                    asks.append((price, 0.0))
-        except (ValueError, TypeError):
-            pass
-
+    def _state_orderbook(self, asset_id: str, state: Dict[str, Any]) -> Dict[str, Any]:
+        bids = sorted(state.get("bids", {}).items(), reverse=True)
+        asks = sorted(state.get("asks", {}).items())
         return {
-            "market_id": market_id,
+            "market_id": state.get("market_id", asset_id),
             "asset_id": asset_id,
             "bids": bids,
             "asks": asks,
-            "timestamp": timestamp,
-            "hash": change.get("hash", ""),
-            "side": change.get("side"),
-            "price": float(change.get("price", 0)) if change.get("price") else None,
-            "size": float(change.get("size", 0)) if change.get("size") else None,
+            "timestamp": state.get("timestamp", 0),
+            "hash": state.get("hash", ""),
         }
 
     async def watch_orderbook_by_asset(self, asset_id: str, callback):
@@ -310,6 +388,21 @@ class PolymarketWebSocket(OrderBookWebSocket):
 
             await self.watch_orderbook(asset_id, make_callback(asset_id))
 
+    async def watch_orderbooks_by_assets(self, asset_callbacks: dict[str, Callable]):
+        """
+        Subscribe to many assets in one websocket request.
+
+        Polymarket sends initial snapshots more reliably when all assets are in
+        a single subscription message. The callback map is keyed by asset ID.
+        """
+        self.subscriptions.update(asset_callbacks)
+        self.subscribed_assets.update(asset_callbacks.keys())
+
+        if self.state != WebSocketState.CONNECTED:
+            await self.connect()
+
+        await self._send_subscription()
+
     def get_orderbook_manager(self) -> OrderbookManager:
         """
         Get the orderbook manager for easy access to orderbook data.
@@ -334,31 +427,33 @@ class PolymarketWebSocket(OrderBookWebSocket):
         """
         try:
             # Parse orderbook data
-            orderbook = self._parse_orderbook_message(data)
-            if not orderbook:
+            parsed = self._parse_orderbook_message(data)
+            if not parsed:
                 return
+            orderbooks = parsed if isinstance(parsed, list) else [parsed]
 
-            # Try both market_id and asset_id as subscription keys
-            market_id = orderbook.get("market_id")
-            asset_id = orderbook.get("asset_id")
+            for orderbook in orderbooks:
+                # Try both market_id and asset_id as subscription keys
+                market_id = orderbook.get("market_id")
+                asset_id = orderbook.get("asset_id")
 
-            # Check which key is in subscriptions
-            callback = None
-            callback_key = None
+                # Check which key is in subscriptions
+                callback = None
+                callback_key = None
 
-            if asset_id and asset_id in self.subscriptions:
-                callback = self.subscriptions[asset_id]
-                callback_key = asset_id
-            elif market_id and market_id in self.subscriptions:
-                callback = self.subscriptions[market_id]
-                callback_key = market_id
+                if asset_id and asset_id in self.subscriptions:
+                    callback = self.subscriptions[asset_id]
+                    callback_key = asset_id
+                elif market_id and market_id in self.subscriptions:
+                    callback = self.subscriptions[market_id]
+                    callback_key = market_id
 
-            if callback and callback_key:
-                # Call callback in a non-blocking way
-                if asyncio.iscoroutinefunction(callback):
-                    await callback(callback_key, orderbook)
-                else:
-                    callback(callback_key, orderbook)
+                if callback and callback_key:
+                    # Call callback in a non-blocking way
+                    if asyncio.iscoroutinefunction(callback):
+                        await callback(callback_key, orderbook)
+                    else:
+                        callback(callback_key, orderbook)
         except Exception as e:
             if self.verbose:
                 logger.debug(f"Error processing message item: {e}")

--- a/dr_manhattan/marketdata/__init__.py
+++ b/dr_manhattan/marketdata/__init__.py
@@ -1,0 +1,5 @@
+"""Market data utilities."""
+
+from .polymarket_relay import PolymarketOrderbookRelay, RelayStats
+
+__all__ = ["PolymarketOrderbookRelay", "RelayStats"]

--- a/dr_manhattan/marketdata/polymarket_relay.py
+++ b/dr_manhattan/marketdata/polymarket_relay.py
@@ -1,0 +1,216 @@
+"""Polymarket orderbook relay utilities.
+
+The relay keeps one upstream Polymarket CLOB websocket connection and fans
+orderbook messages out to local websocket clients. Clients subscribe with:
+
+    {"type": "subscribe", "assets": ["<clob token id>", "..."]}
+
+Book messages are forwarded as compact JSON with relay receive/send timestamps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from dr_manhattan.exchanges.polymarket.polymarket_ws import PolymarketWebSocket
+
+
+def now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+@dataclass(frozen=True)
+class RelayStats:
+    clients: int
+    source_assets: int
+    cached_books: int
+    books_received: int
+    books_sent: int
+
+
+class PolymarketOrderbookRelay:
+    """Fan out one Polymarket orderbook feed to many local clients."""
+
+    def __init__(
+        self,
+        *,
+        verbose: bool = False,
+        refresh_on_client_subscribe: bool = True,
+        stats_interval_sec: float = 30.0,
+        source_factory: Callable[[], PolymarketWebSocket] | None = None,
+    ) -> None:
+        self.verbose = verbose
+        self.refresh_on_client_subscribe = refresh_on_client_subscribe
+        self.stats_interval_sec = max(0.0, stats_interval_sec)
+        self.source_factory = source_factory or self._default_source_factory
+        self.source = self.source_factory()
+        self.clients: set[Any] = set()
+        self.assets_by_client: dict[Any, set[str]] = {}
+        self.last_book_by_asset: dict[str, dict[str, Any]] = {}
+        self._source_receive_task: asyncio.Task | None = None
+        self._stats_task: asyncio.Task | None = None
+        self._source_lock = asyncio.Lock()
+        self.books_received = 0
+        self.books_sent = 0
+
+    @property
+    def stats(self) -> RelayStats:
+        return RelayStats(
+            clients=len(self.clients),
+            source_assets=len(self.source.subscriptions),
+            cached_books=len(self.last_book_by_asset),
+            books_received=self.books_received,
+            books_sent=self.books_sent,
+        )
+
+    async def start(self) -> None:
+        await self.source.connect()
+        self._source_receive_task = asyncio.create_task(self.source._receive_loop())
+        if self.stats_interval_sec > 0:
+            self._stats_task = asyncio.create_task(self._stats_loop())
+        print("polymarket_relay_source_connected", file=sys.stderr, flush=True)
+
+    async def stop(self) -> None:
+        if self._stats_task:
+            self._stats_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._stats_task
+            self._stats_task = None
+        await self._close_source()
+
+    async def handle_client(self, websocket: Any) -> None:
+        self.clients.add(websocket)
+        self.assets_by_client[websocket] = set()
+        peer = getattr(websocket, "remote_address", None)
+        print(f"client_connected peer={peer}", file=sys.stderr, flush=True)
+        try:
+            async for message in websocket:
+                await self.handle_client_message(websocket, message)
+        finally:
+            self.clients.discard(websocket)
+            self.assets_by_client.pop(websocket, None)
+            print(f"client_disconnected peer={peer}", file=sys.stderr, flush=True)
+
+    async def handle_client_message(self, websocket: Any, message: str) -> None:
+        try:
+            payload = json.loads(message)
+        except json.JSONDecodeError:
+            return
+        if payload.get("type") != "subscribe":
+            return
+        assets = {str(asset) for asset in payload.get("assets", []) if asset}
+        self.assets_by_client[websocket] = assets
+        await self._subscribe_client_assets()
+        await websocket.send(
+            json.dumps({"type": "subscribed", "assets": len(assets), "ts_ms": now_ms()})
+        )
+        for asset in sorted(assets):
+            cached = self.last_book_by_asset.get(asset)
+            if cached is not None:
+                await websocket.send(
+                    json.dumps(
+                        {**cached, "replay": True, "relay_sent_ms": now_ms()},
+                        separators=(",", ":"),
+                    )
+                )
+        print(f"client_subscribed assets={len(assets)}", file=sys.stderr, flush=True)
+
+    def _default_source_factory(self) -> PolymarketWebSocket:
+        return PolymarketWebSocket(config={"verbose": self.verbose, "auto_reconnect": True})
+
+    async def _close_source(self) -> None:
+        if self._source_receive_task:
+            self._source_receive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._source_receive_task
+            self._source_receive_task = None
+        await self.source.disconnect()
+
+    async def _subscribe_client_assets(self) -> None:
+        assets = set().union(*self.assets_by_client.values()) if self.assets_by_client else set()
+        current_assets = set(self.source.subscriptions)
+        if not assets:
+            return
+        if current_assets == assets and not self.refresh_on_client_subscribe:
+            return
+
+        callbacks = {asset: self._make_callback(asset) for asset in sorted(assets)}
+        async with self._source_lock:
+            if self.refresh_on_client_subscribe:
+                await self._refresh_source(callbacks)
+            else:
+                new_callbacks = {
+                    asset: callbacks[asset]
+                    for asset in sorted(assets)
+                    if asset not in self.source.subscriptions
+                }
+                if new_callbacks:
+                    await self.source.watch_orderbooks_by_assets(new_callbacks)
+        print(
+            "source_subscribed "
+            f"assets={len(assets)} refreshed={self.refresh_on_client_subscribe} "
+            f"total_assets={len(self.source.subscriptions)}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    async def _refresh_source(self, callbacks: dict[str, Any]) -> None:
+        await self._close_source()
+        self.source = self.source_factory()
+        self.last_book_by_asset.clear()
+        await self.source.connect()
+        self._source_receive_task = asyncio.create_task(self.source._receive_loop())
+        await self.source.watch_orderbooks_by_assets(callbacks)
+
+    def _make_callback(self, asset: str) -> Callable[[str, dict[str, Any]], None]:
+        def callback(_asset_id: str, orderbook: dict[str, Any]) -> None:
+            payload = {
+                "type": "book",
+                "asset_id": asset,
+                "relay_received_ms": now_ms(),
+                "book": orderbook,
+            }
+            self.last_book_by_asset[asset] = payload
+            self.books_received += 1
+            asyncio.create_task(self.broadcast(asset, payload))
+
+        return callback
+
+    async def broadcast(self, asset: str, payload: dict[str, Any]) -> None:
+        if not self.clients:
+            return
+        message = json.dumps({**payload, "relay_sent_ms": now_ms()}, separators=(",", ":"))
+        stale_clients = []
+        for client in list(self.clients):
+            if asset not in self.assets_by_client.get(client, set()):
+                continue
+            try:
+                await client.send(message)
+                self.books_sent += 1
+            except Exception:
+                stale_clients.append(client)
+        for client in stale_clients:
+            self.clients.discard(client)
+            self.assets_by_client.pop(client, None)
+
+    async def _stats_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.stats_interval_sec)
+            stats = self.stats
+            print(
+                "polymarket_relay_stats "
+                f"clients={stats.clients} "
+                f"source_assets={stats.source_assets} "
+                f"cached_books={stats.cached_books} "
+                f"books_received={stats.books_received} "
+                f"books_sent={stats.books_sent}",
+                file=sys.stderr,
+                flush=True,
+            )

--- a/dr_manhattan/runtime/__init__.py
+++ b/dr_manhattan/runtime/__init__.py
@@ -8,6 +8,7 @@ from .order_hooks import (
     OrderResult,
     PostOrderDispatcher,
 )
+from .sqlite_sink import SQLITE_EVENT_SCHEMA, SqliteEvent, SqliteEventSink
 
 __all__ = [
     "AsyncWorker",
@@ -18,4 +19,7 @@ __all__ = [
     "OrderIntent",
     "OrderResult",
     "PostOrderDispatcher",
+    "SQLITE_EVENT_SCHEMA",
+    "SqliteEvent",
+    "SqliteEventSink",
 ]

--- a/dr_manhattan/runtime/sqlite_sink.py
+++ b/dr_manhattan/runtime/sqlite_sink.py
@@ -1,0 +1,270 @@
+"""SQLite event sink backed by AsyncWorker."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from dr_manhattan.models.order import Order
+
+from .async_worker import AsyncWorker, OverflowPolicy, WorkerStats
+from .order_hooks import OrderResult
+
+SCHEMA_VERSION = 1
+
+SQLITE_EVENT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    run_id TEXT PRIMARY KEY,
+    started_ts_ms INTEGER NOT NULL,
+    started_at_utc TEXT NOT NULL,
+    pid INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    sqlite_queue_size INTEGER NOT NULL,
+    overflow_policy TEXT NOT NULL,
+    closed_ts_ms INTEGER,
+    dropped_events INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS run_config_values (
+    run_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    PRIMARY KEY (run_id, key),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    ts_ms INTEGER NOT NULL,
+    event TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_run_ts ON events(run_id, ts_ms);
+CREATE INDEX IF NOT EXISTS idx_events_event_ts ON events(event, ts_ms);
+"""
+
+
+@dataclass(frozen=True)
+class SqliteEvent:
+    event: str
+    ts_ms: int
+    payload: Mapping[str, Any]
+
+
+def now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def json_dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def iso_utc_ms(ts_ms: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts_ms / 1000))
+
+
+class SqliteEventSink:
+    """Persist JSON events to SQLite without blocking the caller.
+
+    The hot path only serializes a small event object and submits it to
+    AsyncWorker. SQLite connection setup, schema creation, and inserts happen in
+    the background thread.
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str] | None,
+        *,
+        run_id: str,
+        name: str = "dr-manhattan-run",
+        config: Mapping[str, Any] | None = None,
+        started_ms: int | None = None,
+        queue_size: int = 10_000,
+        overflow_policy: OverflowPolicy = OverflowPolicy.DROP_NEWEST,
+    ) -> None:
+        self.path = Path(path).expanduser() if path else None
+        if self.path and not self.path.is_absolute():
+            self.path = Path.cwd() / self.path
+        self.run_id = run_id
+        self.name = name
+        self.config = dict(config or {})
+        self.started_ms = started_ms or now_ms()
+        self.queue_size = max(1, int(queue_size))
+        self.overflow_policy = overflow_policy
+        self._conn: sqlite3.Connection | None = None
+        self._closed = False
+        self._worker: AsyncWorker[SqliteEvent] | None = None
+
+        if self.path is not None:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._worker = AsyncWorker(
+                self._handle_event,
+                name=f"{self.name}-sqlite-sink",
+                queue_size=self.queue_size,
+                overflow_policy=self.overflow_policy,
+                on_error=self._on_worker_error,
+            )
+            self.write("run_start", name=self.name)
+
+    @property
+    def enabled(self) -> bool:
+        return self._worker is not None
+
+    @property
+    def stats(self) -> WorkerStats:
+        if self._worker is None:
+            return WorkerStats()
+        return self._worker.stats
+
+    def write(self, event: str, *, ts_ms: int | None = None, **payload: Any) -> bool:
+        """Queue an event for SQLite persistence."""
+        if self._worker is None or self._closed:
+            return False
+        record = SqliteEvent(event=event, ts_ms=ts_ms or now_ms(), payload=payload)
+        return self._worker.submit(record)
+
+    def order_result_hook(self, event: str = "order_result") -> Callable[[OrderResult], None]:
+        """Return a post-order hook that persists OrderResult values."""
+
+        def hook(result: OrderResult) -> None:
+            self.write(event, **order_result_payload(result))
+
+        return hook
+
+    def close(self, *, timeout: float | None = 5.0, drain: bool = True) -> None:
+        if self._worker is None or self._closed:
+            return
+        self._closed = True
+        self._worker.close(timeout=timeout, drain=drain)
+        self._close_connection()
+
+    def _handle_event(self, item: SqliteEvent) -> None:
+        conn = self._ensure_connection()
+        conn.execute(
+            """
+            INSERT INTO events(run_id, ts_ms, event, payload_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            (self.run_id, item.ts_ms, item.event, json_dumps(dict(item.payload))),
+        )
+        conn.commit()
+
+    def _ensure_connection(self) -> sqlite3.Connection:
+        if self._conn is not None:
+            return self._conn
+        if self.path is None:
+            raise RuntimeError("SQLite sink path is disabled")
+        conn = sqlite3.connect(str(self.path), timeout=1.0, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA temp_store=MEMORY")
+        conn.execute("PRAGMA busy_timeout=1000")
+        conn.executescript(SQLITE_EVENT_SCHEMA)
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_meta(key, value) VALUES (?, ?)",
+            ("schema_version", str(SCHEMA_VERSION)),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO runs (
+                run_id, started_ts_ms, started_at_utc, pid, name, config_json,
+                sqlite_queue_size, overflow_policy, dropped_events
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+            """,
+            (
+                self.run_id,
+                self.started_ms,
+                iso_utc_ms(self.started_ms),
+                os.getpid(),
+                self.name,
+                json_dumps(self.config),
+                self.queue_size,
+                self.overflow_policy.value,
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT OR REPLACE INTO run_config_values(run_id, key, value_json)
+            VALUES (?, ?, ?)
+            """,
+            [(self.run_id, key, json_dumps(value)) for key, value in sorted(self.config.items())],
+        )
+        conn.commit()
+        self._conn = conn
+        return conn
+
+    def _close_connection(self) -> None:
+        if self._conn is None:
+            return
+        stats = self.stats
+        self._conn.execute(
+            """
+            UPDATE runs
+            SET closed_ts_ms = ?, dropped_events = ?
+            WHERE run_id = ?
+            """,
+            (now_ms(), stats.dropped, self.run_id),
+        )
+        self._conn.commit()
+        self._conn.close()
+        self._conn = None
+
+    def _on_worker_error(self, exc: BaseException, _item: SqliteEvent) -> None:
+        print(f"sqlite_event_sink failed error={exc}", flush=True)
+
+
+def order_result_payload(result: OrderResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "venue": result.intent.venue,
+        "market_id": result.intent.market_id,
+        "outcome": result.intent.outcome,
+        "side": result.intent.side.value,
+        "price": result.intent.price,
+        "size": result.intent.size,
+        "params": dict(result.intent.params),
+        "context": dict(result.intent.context),
+        "started_ns": result.started_ns,
+        "finished_ns": result.finished_ns,
+        "latency_ms": result.latency_ms,
+        "succeeded": result.succeeded,
+        "metadata": dict(result.metadata),
+    }
+    if result.order is not None:
+        payload["order"] = order_payload(result.order)
+    if result.error is not None:
+        payload["error"] = {
+            "type": result.error.__class__.__name__,
+            "message": str(result.error),
+        }
+    return payload
+
+
+def order_payload(order: Order) -> dict[str, Any]:
+    return {
+        "id": order.id,
+        "market_id": order.market_id,
+        "outcome": order.outcome,
+        "side": order.side.value,
+        "price": order.price,
+        "size": order.size,
+        "filled": order.filled,
+        "status": order.status.value,
+        "created_at": order.created_at.isoformat(),
+        "updated_at": order.updated_at.isoformat() if order.updated_at else None,
+        "time_in_force": order.time_in_force.value,
+    }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,8 @@ Diagnostic and operational tools organized by exchange.
 ```
 scripts/
 ├── polymarket/          # Polymarket-specific utilities
-│   └── check_approval.py
+│   ├── check_approval.py
+│   └── orderbook_relay.py
 └── README.md
 ```
 
@@ -40,6 +41,24 @@ Exchange Allowance: $0.00
 
 ---
 
+### polymarket/orderbook_relay.py
+
+**Purpose:** Run one upstream Polymarket CLOB market websocket and fan out orderbook updates to local websocket clients.
+
+**Usage:**
+```bash
+uv run scripts/polymarket/orderbook_relay.py --host 127.0.0.1 --port 8765
+```
+
+Clients subscribe with:
+```json
+{"type":"subscribe","assets":["<clob token id>"]}
+```
+
+Forwarded messages include `relay_received_ms` and `relay_sent_ms` so clients can measure relay overhead.
+
+---
+
 ## Adding New Scripts
 
 Utility scripts should:
@@ -48,4 +67,3 @@ Utility scripts should:
 3. Require minimal setup (use .env)
 4. Provide clear output and guidance
 5. Handle errors gracefully
-

--- a/scripts/polymarket/orderbook_relay.py
+++ b/scripts/polymarket/orderbook_relay.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Run a local Polymarket orderbook websocket relay."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import signal
+
+import websockets
+
+from dr_manhattan.marketdata import PolymarketOrderbookRelay
+
+
+async def main_async(args: argparse.Namespace) -> None:
+    relay = PolymarketOrderbookRelay(
+        verbose=args.verbose,
+        refresh_on_client_subscribe=not args.no_refresh_on_client_subscribe,
+        stats_interval_sec=args.stats_interval_sec,
+    )
+    await relay.start()
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signame in ("SIGINT", "SIGTERM"):
+        loop.add_signal_handler(getattr(signal, signame), stop_event.set)
+
+    async with websockets.serve(
+        relay.handle_client,
+        args.host,
+        args.port,
+        ping_interval=10,
+        ping_timeout=5,
+        close_timeout=2,
+        max_size=10 * 1024 * 1024,
+        compression=None,
+    ):
+        print(f"polymarket_relay_listening host={args.host} port={args.port}", flush=True)
+        await stop_event.wait()
+    await relay.stop()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Polymarket orderbook websocket relay")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--no-refresh-on-client-subscribe",
+        action="store_true",
+        help="Subscribe only newly requested assets instead of refreshing the upstream batch.",
+    )
+    parser.add_argument("--stats-interval-sec", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    asyncio.run(main_async(parse_args()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_polymarket_relay.py
+++ b/tests/test_polymarket_relay.py
@@ -1,0 +1,122 @@
+import json
+
+import pytest
+
+from dr_manhattan.base.websocket import WebSocketState
+from dr_manhattan.exchanges.polymarket.polymarket_ws import PolymarketWebSocket
+from dr_manhattan.marketdata import PolymarketOrderbookRelay
+
+
+class FakeClient:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message):
+        self.sent.append(json.loads(message))
+
+
+class FakeSource:
+    def __init__(self):
+        self.subscriptions = {}
+        self.connected = False
+        self.disconnected = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def _receive_loop(self):
+        return None
+
+    async def watch_orderbooks_by_assets(self, callbacks):
+        self.subscriptions.update(callbacks)
+
+
+class FakeWire:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message):
+        self.sent.append(json.loads(message))
+
+
+@pytest.mark.asyncio
+async def test_polymarket_relay_subscribes_union_of_client_assets():
+    source = FakeSource()
+    relay = PolymarketOrderbookRelay(
+        source_factory=lambda: source,
+        refresh_on_client_subscribe=False,
+        stats_interval_sec=0,
+    )
+    client = FakeClient()
+
+    await relay.handle_client_message(
+        client,
+        json.dumps({"type": "subscribe", "assets": ["asset-b", "asset-a"]}),
+    )
+
+    assert set(source.subscriptions) == {"asset-a", "asset-b"}
+    assert client.sent[0]["type"] == "subscribed"
+    assert client.sent[0]["assets"] == 2
+
+
+@pytest.mark.asyncio
+async def test_polymarket_relay_broadcasts_only_to_subscribed_clients():
+    relay = PolymarketOrderbookRelay(source_factory=FakeSource, stats_interval_sec=0)
+    subscribed = FakeClient()
+    other = FakeClient()
+    relay.clients = {subscribed, other}
+    relay.assets_by_client = {subscribed: {"asset-1"}, other: {"asset-2"}}
+
+    await relay.broadcast("asset-1", {"type": "book", "asset_id": "asset-1", "book": {}})
+
+    assert len(subscribed.sent) == 1
+    assert subscribed.sent[0]["asset_id"] == "asset-1"
+    assert "relay_sent_ms" in subscribed.sent[0]
+    assert other.sent == []
+
+
+@pytest.mark.asyncio
+async def test_polymarket_ws_sends_full_asset_subscription_batch():
+    ws = PolymarketWebSocket()
+    ws.ws = FakeWire()
+    ws.state = WebSocketState.CONNECTED
+
+    await ws.watch_orderbooks_by_assets({"asset-2": lambda *_: None, "asset-1": lambda *_: None})
+
+    message = ws.ws.sent[-1]
+    assert set(message["assets_ids"]) == {"asset-1", "asset-2"}
+    assert message["custom_feature_enabled"] is True
+    assert message["type"] == "market"
+
+
+def test_polymarket_ws_price_change_updates_cached_depth_for_multiple_assets():
+    ws = PolymarketWebSocket()
+    ws._parse_book_message(
+        {
+            "event_type": "book",
+            "market": "m1",
+            "asset_id": "asset-1",
+            "timestamp": 1,
+            "bids": [{"price": "0.40", "size": "10"}],
+            "asks": [{"price": "0.42", "size": "12"}],
+        }
+    )
+
+    updates = ws._parse_price_change_message(
+        {
+            "event_type": "price_change",
+            "market": "m1",
+            "timestamp": 2,
+            "price_changes": [
+                {"asset_id": "asset-1", "side": "BUY", "price": "0.41", "size": "3"},
+                {"asset_id": "asset-2", "side": "SELL", "price": "0.61", "size": "4"},
+            ],
+        }
+    )
+
+    assert [update["asset_id"] for update in updates] == ["asset-1", "asset-2"]
+    assert updates[0]["bids"][0] == (0.41, 3.0)
+    assert updates[1]["asks"] == [(0.61, 4.0)]

--- a/tests/test_sqlite_sink.py
+++ b/tests/test_sqlite_sink.py
@@ -1,0 +1,90 @@
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from dr_manhattan.models.order import Order, OrderSide, OrderStatus
+from dr_manhattan.runtime import OrderIntent, OrderResult, SqliteEventSink
+
+
+def test_sqlite_event_sink_persists_config_and_events(tmp_path):
+    db_path = tmp_path / "events.sqlite3"
+    sink = SqliteEventSink(
+        db_path,
+        run_id="run-1",
+        name="test-run",
+        config={"threshold_bps": 200, "venues": ["polymarket", "target-venue"]},
+    )
+
+    assert sink.write("opportunity_seen", market_id="m1", edge_bps=250)
+    sink.close()
+
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        run = con.execute("SELECT * FROM runs WHERE run_id = 'run-1'").fetchone()
+        assert run["name"] == "test-run"
+        assert json.loads(run["config_json"]) == {
+            "threshold_bps": 200,
+            "venues": ["polymarket", "target-venue"],
+        }
+        config_rows = {
+            row["key"]: json.loads(row["value_json"])
+            for row in con.execute("SELECT key, value_json FROM run_config_values")
+        }
+        assert config_rows == {
+            "threshold_bps": 200,
+            "venues": ["polymarket", "target-venue"],
+        }
+        events = con.execute("SELECT event, payload_json FROM events ORDER BY id").fetchall()
+        assert [row["event"] for row in events] == ["run_start", "opportunity_seen"]
+        assert json.loads(events[1]["payload_json"]) == {"edge_bps": 250, "market_id": "m1"}
+    finally:
+        con.close()
+
+
+def test_sqlite_event_sink_can_be_used_as_post_order_hook(tmp_path):
+    db_path = tmp_path / "orders.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-2", config={"mode": "test"})
+    hook = sink.order_result_hook()
+    intent = OrderIntent(
+        venue="target-venue",
+        market_id="123",
+        outcome="Yes",
+        side=OrderSide.BUY,
+        price=0.42,
+        size=2,
+    )
+    order = Order(
+        id="order-1",
+        market_id="123",
+        outcome="Yes",
+        side=OrderSide.BUY,
+        price=0.42,
+        size=2,
+        filled=0,
+        status=OrderStatus.OPEN,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    hook(OrderResult.success(intent, order, started_ns=1_000_000, finished_ns=3_000_000))
+    sink.close()
+
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute("SELECT payload_json FROM events WHERE event = 'order_result'").fetchone()
+        payload = json.loads(row["payload_json"])
+        assert payload["venue"] == "target-venue"
+        assert payload["latency_ms"] == 2.0
+        assert payload["order"]["id"] == "order-1"
+        assert payload["succeeded"] is True
+    finally:
+        con.close()
+
+
+def test_sqlite_event_sink_disabled_without_path():
+    sink = SqliteEventSink(None, run_id="disabled")
+
+    assert sink.enabled is False
+    assert sink.write("event") is False
+    assert sink.stats.submitted == 0


### PR DESCRIPTION
## Summary
- add a reusable Polymarket orderbook relay utility and CLI wrapper
- improve Polymarket websocket subscriptions with full-asset batch subscription and multi-asset price-change parsing
- add a generic AsyncWorker-backed SQLite event sink with run config persistence and an OrderResult post-order hook adapter

## Boundary
- no World Cup live runner, market mappings, Hooker alerts, private sizing logic, or strategy code included
- Predict.fun driver refresh remains separate in PR #95

## Verification
- uv run black dr_manhattan/exchanges/polymarket/polymarket_ws.py dr_manhattan/marketdata dr_manhattan/runtime/sqlite_sink.py tests/test_polymarket_relay.py tests/test_sqlite_sink.py scripts/polymarket/orderbook_relay.py
- uv run ruff check dr_manhattan/exchanges/polymarket/polymarket_ws.py dr_manhattan/marketdata dr_manhattan/runtime/sqlite_sink.py tests/test_polymarket_relay.py tests/test_sqlite_sink.py scripts/polymarket/orderbook_relay.py
- uv run mypy
- uv run pytest -q