### PR TITLE
Preserve Predict.fun websocket update timestamps

### DIFF
--- a/dr_manhattan/exchanges/predictfun_ws.py
+++ b/dr_manhattan/exchanges/predictfun_ws.py
@@ -220,11 +220,16 @@ class PredictFunWebSocket(OrderBookWebSocket):
         bids.sort(reverse=True)
         asks.sort()
 
+        timestamp = (
+            data.get("updateTimestampMs") or data.get("timestamp") or int(time.time() * 1000)
+        )
+
         return {
             "market_id": market_id,
             "bids": bids,
             "asks": asks,
-            "timestamp": data.get("timestamp", int(time.time() * 1000)),
+            "timestamp": timestamp,
+            "updateTimestampMs": data.get("updateTimestampMs"),
         }
 
     async def _send_heartbeat_response(self):

--- a/tests/test_predictfun.py
+++ b/tests/test_predictfun.py
@@ -6,6 +6,7 @@ import pytest
 
 from dr_manhattan.base.errors import AuthenticationError, ExchangeError, InvalidOrder
 from dr_manhattan.exchanges.predictfun import PredictFun
+from dr_manhattan.exchanges.predictfun_ws import PredictFunWebSocket
 from dr_manhattan.models.order import OrderSide, OrderStatus
 
 
@@ -524,3 +525,22 @@ def test_fetch_order_matches_forwards_filters(monkeypatch):
         },
         "require_auth": False,
     }
+
+
+def test_predictfun_websocket_preserves_update_timestamp():
+    ws = PredictFunWebSocket()
+
+    parsed = ws._parse_orderbook_message(
+        {
+            "type": "M",
+            "topic": "predictOrderbook/1518",
+            "data": {
+                "updateTimestampMs": 1782098035543,
+                "bids": [{"price": "0.12", "size": "10"}],
+                "asks": [{"price": "0.13", "size": "20"}],
+            },
+        }
+    )
+
+    assert parsed["timestamp"] == 1782098035543
+    assert parsed["updateTimestampMs"] == 1782098035543


### PR DESCRIPTION
## Summary
- keep Predict.fun orderbook updateTimestampMs on parsed websocket orderbook payloads
- use updateTimestampMs as the normalized timestamp when present
- add a regression test for predictOrderbook messages

## Verification
- uv run pytest tests/test_predictfun.py -q
- uv run ruff check dr_manhattan/exchanges/predictfun_ws.py tests/test_predictfun.py
- uv run mypy
- uv run pytest -q