### PR TITLE
Add single-outcome (one-sided delta) mode to spread strategy

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,7 +57,7 @@ uv run python examples/find_common_markets.py
 
 **Exchange-agnostic BBO market making strategy.**
 
-Works with Polymarket, Opinion, Limitless, Kalshi, or any exchange implementing the standard interface.
+Works with Polymarket, Opinion, Limitless, Kalshi, or any exchange implementing the standard interface. On each tick it joins the best bid/ask for every quoted outcome and never shorts (it only sells an outcome it already holds).
 
 **Usage:**
 ```bash
@@ -79,10 +79,37 @@ EXCHANGE=polymarket MARKET_SLUG=fed-decision uv run python examples/spread_strat
 
 **Options:**
 - `--exchange, -e`: Exchange name (polymarket, opinion, limitless, kalshi)
-- `--market-id, -m`: Market ID
+- `--market-id, -m`: Market ID (Polymarket: Gamma numeric id, token id, or slug)
 - `--slug, -s`: Market slug/keyword for search
 - `--max-position`: Max position per outcome (default: 100)
 - `--order-size`: Order size (default: 5)
+- `--max-delta`: Max position imbalance before throttling the heavier side (default: 20)
+- `--interval`: Seconds between ticks (default: 5)
+- `--outcome`: Quote only this outcome's book, e.g. `Yes` (default: quote all outcomes)
+- `--no-liquidate`: On shutdown, cancel orders but keep the position (default: sell to flat at the bid)
+- `--duration`: Auto-stop after N minutes (default: run until interrupted)
+- `--env-file`: Path to a `.env` for credentials (default: nearest `.env`)
+
+### Single-outcome market making (one-sided delta)
+
+To make a two-sided market but only ever carry inventory on one side (e.g. accumulate YES, never NO), quote a single outcome and keep the position on shutdown:
+
+```bash
+uv run python examples/spread_strategy.py \
+  -e polymarket --market-id 2672689 \
+  --outcome Yes --order-size 5 --max-position 10 \
+  --interval 3 --no-liquidate \
+  --env-file /path/to/.env
+```
+
+This bids YES to build a position and asks YES only down to flat (the no-short guard prevents going short), so residual delta is always long-or-flat YES.
+
+Notes:
+- In single-outcome mode the `delta` metric (max minus min across outcomes) stays 0, so **`--max-position` is the real inventory cap**, not `--max-delta`. Above, YES is capped at 10 contracts (two 5-lots; Polymarket's min order size is 5).
+- `--no-liquidate` is what "leaves the delta": the default shutdown sells the position at the bid, which would dump inventory you intend to hold.
+- Near a binary resolution a passive maker is adversely selected (a resting bid tends to fill when the outcome is heading against you), so the carried delta is effectively a directional bet. Size `--max-position` accordingly.
+
+**Before trading:** confirm the funder wallet has USDC and exchange allowance with `uv run python scripts/polymarket/check_approval.py`.
 
 **Warning:** This places REAL orders with REAL money.
 

--- a/examples/spread_strategy.py
+++ b/examples/spread_strategy.py
@@ -26,12 +26,59 @@ class SpreadStrategy(Strategy):
 
     Joins the best bid and ask on each tick using REST API polling.
     Works with any exchange that implements the standard interface.
+
+    Options:
+        outcome: If set, quote only this outcome's book (e.g. "Yes"). The
+            no-short guard in place_bbo_orders keeps inventory long-or-flat on
+            that single outcome, so residual delta sits only on that side. In
+            single-outcome mode max_position is the effective inventory cap
+            (calculate_delta is max-min across outcomes, which is 0 here).
+        liquidate_on_stop: If False, shutdown cancels resting quotes but keeps
+            the position instead of selling it at the bid.
     """
+
+    def __init__(
+        self,
+        *args,
+        outcome: Optional[str] = None,
+        liquidate_on_stop: bool = True,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.outcome_filter = outcome
+        self.liquidate_on_stop = liquidate_on_stop
+
+    def setup(self) -> bool:
+        """Fetch market, then optionally restrict quoting to a single outcome."""
+        if not super().setup():
+            return False
+        if self.outcome_filter:
+            wanted = self.outcome_filter.strip().lower()
+            matched = [ot for ot in self.outcome_tokens if ot.outcome.strip().lower() == wanted]
+            if not matched:
+                available = [ot.outcome for ot in self.outcome_tokens]
+                logger.error(f"Outcome '{self.outcome_filter}' not found. Available: {available}")
+                return False
+            self.outcome_tokens = matched
+            logger.info(
+                f"{Colors.bold('Quoting single outcome only:')} "
+                f"{Colors.magenta(matched[0].outcome)}"
+            )
+        return True
 
     def on_tick(self) -> None:
         """Main trading logic."""
         self.log_status()
         self.place_bbo_orders()
+
+    def cleanup(self) -> None:
+        """Shutdown. Preserve inventory when liquidate_on_stop is False."""
+        if self.liquidate_on_stop:
+            super().cleanup()
+            return
+        logger.info(f"\n{Colors.bold('Cleaning up (preserving positions)...')}")
+        self.cancel_all_orders()
+        self.client.stop()
 
 
 def find_market_id(
@@ -139,13 +186,38 @@ def parse_args() -> argparse.Namespace:
         default=float(os.getenv("CHECK_INTERVAL", "5")),
         help="Check interval in seconds (default: 5)",
     )
+    parser.add_argument(
+        "--outcome",
+        default=os.getenv("OUTCOME") or None,
+        help="Quote only this outcome's book (e.g. 'Yes'). Default: quote all outcomes.",
+    )
+    parser.add_argument(
+        "--no-liquidate",
+        action="store_true",
+        help="On shutdown, cancel orders but keep the position (don't sell at the bid).",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Auto-stop after this many minutes (default: run until interrupted).",
+    )
+    parser.add_argument(
+        "--env-file",
+        default=os.getenv("ENV_FILE") or None,
+        help="Path to a .env file for credentials (default: nearest .env).",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     """Entry point for the spread strategy."""
+    # Load nearest .env so env-based argument defaults resolve, then let an
+    # explicit --env-file override the credentials.
     load_dotenv()
     args = parse_args()
+    if args.env_file:
+        load_dotenv(args.env_file, override=True)
 
     if not args.market_id and not args.slug:
         logger.error("Provide --market-id or --slug")
@@ -173,8 +245,10 @@ def main() -> int:
         order_size=args.order_size,
         max_delta=args.max_delta,
         check_interval=args.interval,
+        outcome=args.outcome,
+        liquidate_on_stop=not args.no_liquidate,
     )
-    strategy.run()
+    strategy.run(duration_minutes=args.duration)
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds a single-outcome mode to the BBO spread strategy so the maker can quote one outcome's book only (e.g. accumulate YES, never NO) and carry residual delta on that side while still capturing spread.

- `--outcome`: restrict quoting to one outcome; the no-short guard keeps inventory long-or-flat on that side, and `max_position` becomes the effective inventory cap
- `--no-liquidate`: on shutdown, cancel resting quotes but preserve the position instead of selling at the bid
- `--duration`: auto-stop after N minutes
- `--env-file`: load credentials from a specific .env (explicit override of the nearest .env)
- Documents the one-sided-delta workflow, the max-position cap, and the adverse-selection caveat in `examples/README.md`

## Testing

- Full suite: 340 passed, 11 skipped
- `ruff check` / `ruff format --check`: clean
- CLI smoke: all four new flags render in `--help`; `Strategy.run(duration_minutes=)` already exists upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)