### PR TITLE
Harden sqlite sink money path

### DIFF
--- a/dr_manhattan/runtime/async_worker.py
+++ b/dr_manhattan/runtime/async_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import queue
 import threading
+from collections import deque
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Generic, TypeVar
@@ -27,6 +28,7 @@ class WorkerStats:
     failed: int = 0
     dropped: int = 0
     queue_size: int = 0
+    critical_pending: int = 0
 
 
 class AsyncWorker(Generic[T]):
@@ -34,8 +36,12 @@ class AsyncWorker(Generic[T]):
 
     The SDK is mostly synchronous, so this class intentionally uses a thread
     rather than requiring users to own an asyncio event loop. It is intended for
-    durable but non-critical side effects such as alerts, metrics, and SQLite
-    writes. Do not use it for checks that must approve an order before submit.
+    durable side effects such as alerts, metrics, and SQLite writes. Do not use
+    it for checks that must approve an order before submit.
+
+    Items submitted with critical=True go through an unbounded lane that the
+    worker drains before the bounded queue. They are never dropped and never
+    block the caller, regardless of the overflow policy.
     """
 
     def __init__(
@@ -54,7 +60,9 @@ class AsyncWorker(Generic[T]):
         self.overflow_policy = overflow_policy
         self.on_error = on_error
         self._queue: queue.Queue[T | object] = queue.Queue(maxsize=queue_size)
+        self._critical: deque[T] = deque()
         self._sentinel = object()
+        self._critical_token = object()
         self._lock = threading.Lock()
         self._closed = False
         self._thread: threading.Thread | None = None
@@ -70,17 +78,35 @@ class AsyncWorker(Generic[T]):
             self._thread = threading.Thread(target=self._run, name=self.name, daemon=True)
             self._thread.start()
 
-    def submit(self, item: T, *, timeout: float | None = None) -> bool:
+    def submit(self, item: T, *, timeout: float | None = None, critical: bool = False) -> bool:
         """Queue an item for background processing.
 
         Returns False when the configured overflow policy drops the item or the
         worker is already closed.
+
+        With critical=True the item bypasses the overflow policy: it is
+        appended to an unbounded lane processed ahead of regular items, so it
+        is never dropped under queue pressure and never blocks the caller.
+        Losing telemetry degrades analytics; losing a money-path record
+        corrupts the ledger.
         """
 
         self.start()
         with self._lock:
             if self._closed:
                 return False
+
+        if critical:
+            self._critical.append(item)
+            self._increment_submitted()
+            try:
+                # Wake the worker if it is blocked on an empty queue. A full
+                # queue means it is already busy and will drain the critical
+                # lane before its next regular item.
+                self._queue.put_nowait(self._critical_token)
+            except queue.Full:
+                pass
+            return True
 
         if self.overflow_policy == OverflowPolicy.BLOCK:
             try:
@@ -113,7 +139,12 @@ class AsyncWorker(Generic[T]):
         """Stop the worker.
 
         With drain=True, all already queued items are processed before the
-        worker exits. With drain=False, queued items are discarded first.
+        worker exits. With drain=False, queued regular items are discarded
+        first, but pending critical items are still processed: money-path
+        records must outlive a fast shutdown. Both flushes are bounded by
+        timeout: a handler stuck in retries (e.g. the SQLite sink's ~6s worst
+        case for a poison event) can outlive the default 5s join, so pass a
+        larger timeout when the final flush must complete.
         """
 
         with self._lock:
@@ -139,30 +170,48 @@ class AsyncWorker(Generic[T]):
                 failed=self._failed,
                 dropped=self._dropped,
                 queue_size=self._queue.qsize(),
+                critical_pending=len(self._critical),
             )
 
     def _run(self) -> None:
         while True:
+            self._drain_critical()
             item = self._queue.get()
             try:
                 if item is self._sentinel:
+                    self._drain_critical()
                     return
-                self.handler(item)  # type: ignore[arg-type]
-                self._increment_processed()
-            except BaseException as exc:
-                self._increment_failed()
-                if item is not self._sentinel and self.on_error is not None:
-                    self.on_error(exc, item)  # type: ignore[arg-type]
+                if item is self._critical_token:
+                    continue
+                self._process(item)  # type: ignore[arg-type]
             finally:
                 self._queue.task_done()
 
+    def _drain_critical(self) -> None:
+        while True:
+            try:
+                item = self._critical.popleft()
+            except IndexError:
+                return
+            self._process(item)
+
+    def _process(self, item: T) -> None:
+        try:
+            self.handler(item)
+            self._increment_processed()
+        except BaseException as exc:
+            self._increment_failed()
+            if self.on_error is not None:
+                self.on_error(exc, item)
+
     def _drop_oldest_pending(self) -> bool:
         try:
-            self._queue.get_nowait()
+            item = self._queue.get_nowait()
         except queue.Empty:
             return False
         self._queue.task_done()
-        self._increment_dropped()
+        if item is not self._critical_token:
+            self._increment_dropped()
         return True
 
     def _drop_all_pending(self) -> None:
@@ -172,7 +221,7 @@ class AsyncWorker(Generic[T]):
                 item = self._queue.get_nowait()
             except queue.Empty:
                 break
-            if item is not self._sentinel:
+            if item is not self._sentinel and item is not self._critical_token:
                 dropped += 1
             self._queue.task_done()
         if dropped:

--- a/dr_manhattan/runtime/order_hooks.py
+++ b/dr_manhattan/runtime/order_hooks.py
@@ -192,7 +192,9 @@ class OrderHookPipeline:
 
     def emit_result(self, result: OrderResult) -> bool:
         if self.post_order_worker is not None:
-            return self.post_order_worker.submit(result)
+            # Order results are money-path records: never drop them under
+            # queue pressure, even when the worker uses a lossy policy.
+            return self.post_order_worker.submit(result, critical=True)
         self.dispatcher(result)
         return True
 

--- a/dr_manhattan/runtime/sqlite_sink.py
+++ b/dr_manhattan/runtime/sqlite_sink.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from dr_manhattan.models.order import Order
 
@@ -16,6 +18,10 @@ from .async_worker import AsyncWorker, OverflowPolicy, WorkerStats
 from .order_hooks import OrderResult
 
 SCHEMA_VERSION = 1
+
+# Attempts per event before it is surfaced to on_error; the connection is
+# reset between attempts so a broken cached connection cannot wedge the sink.
+SQLITE_WRITE_ATTEMPTS = 3
 
 SQLITE_EVENT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -83,6 +89,10 @@ class SqliteEventSink:
     The hot path only serializes a small event object and submits it to
     AsyncWorker. SQLite connection setup, schema creation, and inserts happen in
     the background thread.
+
+    Events named in critical_events (and writes with critical=True) are
+    money-path records: they are never dropped under queue pressure, and they
+    are flushed even on close(drain=False).
     """
 
     def __init__(
@@ -95,6 +105,7 @@ class SqliteEventSink:
         started_ms: int | None = None,
         queue_size: int = 10_000,
         overflow_policy: OverflowPolicy = OverflowPolicy.DROP_NEWEST,
+        critical_events: Iterable[str] = ("order_result",),
     ) -> None:
         self.path = Path(path).expanduser() if path else None
         if self.path and not self.path.is_absolute():
@@ -105,9 +116,14 @@ class SqliteEventSink:
         self.started_ms = started_ms or now_ms()
         self.queue_size = max(1, int(queue_size))
         self.overflow_policy = overflow_policy
+        self.critical_events = frozenset(critical_events)
         self._conn: sqlite3.Connection | None = None
         self._closed = False
         self._worker: AsyncWorker[SqliteEvent] | None = None
+        self._drop_lock = threading.Lock()
+        self._dropped_by_event: dict[str, int] = {}
+        self._dropped_total = 0
+        self._write_failures = 0
 
         if self.path is not None:
             self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -130,18 +146,40 @@ class SqliteEventSink:
             return WorkerStats()
         return self._worker.stats
 
-    def write(self, event: str, *, ts_ms: int | None = None, **payload: Any) -> bool:
-        """Queue an event for SQLite persistence."""
+    @property
+    def dropped_by_event(self) -> dict[str, int]:
+        """Copy of per-event drop counts for regular events lost to queue pressure."""
+        with self._drop_lock:
+            return dict(self._dropped_by_event)
+
+    def write(
+        self,
+        event: str,
+        *,
+        ts_ms: int | None = None,
+        critical: bool | None = None,
+        **payload: Any,
+    ) -> bool:
+        """Queue an event for SQLite persistence.
+
+        critical=None resolves against critical_events; critical events are
+        never dropped under queue pressure.
+        """
         if self._worker is None or self._closed:
             return False
         record = SqliteEvent(event=event, ts_ms=ts_ms or now_ms(), payload=payload)
-        return self._worker.submit(record)
+        if critical is None:
+            critical = event in self.critical_events
+        accepted = self._worker.submit(record, critical=critical)
+        if not accepted:
+            self._record_drop(event)
+        return accepted
 
     def order_result_hook(self, event: str = "order_result") -> Callable[[OrderResult], None]:
         """Return a post-order hook that persists OrderResult values."""
 
         def hook(result: OrderResult) -> None:
-            self.write(event, **order_result_payload(result))
+            self.write(event, critical=True, **order_result_payload(result))
 
         return hook
 
@@ -153,15 +191,51 @@ class SqliteEventSink:
         self._close_connection()
 
     def _handle_event(self, item: SqliteEvent) -> None:
-        conn = self._ensure_connection()
-        conn.execute(
-            """
-            INSERT INTO events(run_id, ts_ms, event, payload_json)
-            VALUES (?, ?, ?, ?)
-            """,
-            (self.run_id, item.ts_ms, item.event, json_dumps(dict(item.payload))),
-        )
-        conn.commit()
+        payload_json = json_dumps(dict(item.payload))
+        # A failed write must never leave the sink permanently dark while the
+        # process keeps trading: reset the cached connection and retry before
+        # surfacing the event to on_error.
+        last_exc: Exception | None = None
+        for _ in range(SQLITE_WRITE_ATTEMPTS):
+            try:
+                conn = self._ensure_connection()
+                conn.execute(
+                    """
+                    INSERT INTO events(run_id, ts_ms, event, payload_json)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (self.run_id, item.ts_ms, item.event, payload_json),
+                )
+                conn.commit()
+                return
+            except Exception as exc:
+                last_exc = exc
+                self._reset_connection()
+        if last_exc is None:
+            raise RuntimeError("sqlite write retry loop exited without a result")
+        raise last_exc
+
+    def _record_drop(self, event: str) -> None:
+        line = None
+        with self._drop_lock:
+            self._dropped_by_event[event] = self._dropped_by_event.get(event, 0) + 1
+            self._dropped_total += 1
+            total = self._dropped_total
+            if total == 1 or total % 1000 == 0:
+                top = sorted(self._dropped_by_event.items(), key=lambda kv: -kv[1])[:3]
+                top_text = ",".join(f"{name}:{count}" for name, count in top)
+                line = f"sqlite_event_sink queue_full dropped_events={total} top={top_text}"
+        if line:
+            print(line, file=sys.stderr)
+
+    def _reset_connection(self) -> None:
+        conn, self._conn = self._conn, None
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except Exception:
+            pass
 
     def _ensure_connection(self) -> sqlite3.Connection:
         if self._conn is not None:
@@ -209,23 +283,38 @@ class SqliteEventSink:
         return conn
 
     def _close_connection(self) -> None:
-        if self._conn is None:
+        if self.path is None:
             return
         stats = self.stats
-        self._conn.execute(
-            """
-            UPDATE runs
-            SET closed_ts_ms = ?, dropped_events = ?
-            WHERE run_id = ?
-            """,
-            (now_ms(), stats.dropped, self.run_id),
-        )
-        self._conn.commit()
-        self._conn.close()
-        self._conn = None
+        # The connection may have been reset by a mid-run write failure;
+        # reconnect so the run row still gets finalized.
+        try:
+            conn = self._ensure_connection()
+            conn.execute(
+                """
+                UPDATE runs
+                SET closed_ts_ms = ?, dropped_events = ?
+                WHERE run_id = ?
+                """,
+                (now_ms(), stats.dropped, self.run_id),
+            )
+            conn.commit()
+            conn.close()
+        except Exception as exc:
+            print(f"sqlite_event_sink close failed error={exc}", file=sys.stderr)
+        finally:
+            self._conn = None
 
-    def _on_worker_error(self, exc: BaseException, _item: SqliteEvent) -> None:
-        print(f"sqlite_event_sink failed error={exc}", flush=True)
+    def _on_worker_error(self, exc: BaseException, item: SqliteEvent) -> None:
+        # Called from the worker thread only.
+        self._write_failures += 1
+        failures = self._write_failures
+        if failures == 1 or failures % 100 == 0:
+            print(
+                f"sqlite_event_sink write failed (failures={failures}) "
+                f"event={item.event} error={exc}",
+                file=sys.stderr,
+            )
 
 
 def order_result_payload(result: OrderResult) -> dict[str, Any]:

--- a/tests/test_runtime_worker_hooks.py
+++ b/tests/test_runtime_worker_hooks.py
@@ -1,5 +1,6 @@
+import time
 from datetime import datetime, timezone
-from threading import Event
+from threading import Event, Thread
 
 from dr_manhattan.models.order import Order, OrderSide, OrderStatus
 from dr_manhattan.runtime import (
@@ -51,6 +52,81 @@ def test_async_worker_drop_newest_overflow_is_non_blocking():
     assert worker.stats.dropped == 1
 
 
+def wait_until(condition, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(0.005)
+    return condition()
+
+
+def test_async_worker_critical_lane_bypasses_full_queue():
+    entered = Event()
+    release = Event()
+    processed = []
+
+    def handler(item):
+        entered.set()
+        release.wait(timeout=5)
+        processed.append(item)
+
+    worker = AsyncWorker(handler, queue_size=1, overflow_policy=OverflowPolicy.DROP_NEWEST)
+    assert worker.submit("first")
+    assert entered.wait(timeout=1)
+    assert worker.submit("second")
+    assert worker.submit("third") is False
+    assert worker.submit("critical-1", critical=True)
+    assert worker.submit("critical-2", critical=True)
+    assert worker.stats.critical_pending == 2
+
+    release.set()
+    worker.close()
+
+    assert processed == ["first", "critical-1", "critical-2", "second"]
+    assert worker.stats.submitted == 4
+    assert worker.stats.dropped == 1
+    assert worker.stats.critical_pending == 0
+
+
+def test_async_worker_critical_wakes_idle_worker():
+    processed = []
+
+    worker = AsyncWorker(processed.append, queue_size=4)
+    assert worker.submit("money", critical=True)
+
+    assert wait_until(lambda: worker.stats.processed == 1)
+    worker.close()
+
+    assert processed == ["money"]
+
+
+def test_async_worker_close_without_drain_still_flushes_critical():
+    entered = Event()
+    release = Event()
+    processed = []
+
+    def handler(item):
+        entered.set()
+        release.wait(timeout=5)
+        processed.append(item)
+
+    worker = AsyncWorker(handler, queue_size=1)
+    assert worker.submit("regular-1")
+    assert entered.wait(timeout=1)
+    assert worker.submit("regular-2")
+    assert worker.submit("critical-1", critical=True)
+
+    closer = Thread(target=lambda: worker.close(drain=False))
+    closer.start()
+    assert wait_until(lambda: worker.stats.dropped >= 1)
+    release.set()
+    closer.join(timeout=5)
+
+    assert processed == ["regular-1", "critical-1"]
+    assert worker.stats.dropped == 1
+
+
 def test_order_pipeline_runs_pre_order_hooks_synchronously():
     intent = OrderIntent(
         venue="predictfun",
@@ -96,6 +172,39 @@ def test_order_pipeline_queues_post_order_hooks():
     pipeline.close()
 
     assert received == ["order-1"]
+
+
+def test_order_pipeline_emit_result_survives_full_post_order_queue():
+    entered = Event()
+    release = Event()
+    received = []
+
+    def slow_hook(item):
+        entered.set()
+        release.wait(timeout=5)
+        received.append(item)
+
+    pipeline = OrderHookPipeline(
+        post_order_hooks=[slow_hook],
+        post_order_async=True,
+        post_order_queue_size=1,
+    )
+    worker = pipeline.post_order_worker
+    assert worker is not None
+    assert worker.submit("blocker")
+    assert entered.wait(timeout=1)
+    assert worker.submit("filler")
+    assert worker.submit("overflow") is False
+
+    intent = OrderIntent("123", "Yes", OrderSide.BUY, 0.42, 2)
+    result = OrderResult.success(intent, sample_order(), started_ns=1, finished_ns=2)
+    assert pipeline.emit_result(result)
+
+    release.set()
+    pipeline.close()
+
+    assert received == ["blocker", result, "filler"]
+    assert worker.stats.dropped == 1
 
 
 def test_order_pipeline_dispatches_post_hooks_without_failing_other_hooks():

--- a/tests/test_sqlite_sink.py
+++ b/tests/test_sqlite_sink.py
@@ -1,9 +1,43 @@
 import json
 import sqlite3
+import time
 from datetime import datetime, timezone
+from threading import Event
 
 from dr_manhattan.models.order import Order, OrderSide, OrderStatus
 from dr_manhattan.runtime import OrderIntent, OrderResult, SqliteEventSink
+
+
+def wait_until(condition, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(0.005)
+    return condition()
+
+
+def gate_worker(sink):
+    """Wrap the sink's handler so the worker blocks until the gate is set."""
+    entered = Event()
+    gate = Event()
+    inner = sink._worker.handler
+
+    def gated(item):
+        entered.set()
+        assert gate.wait(timeout=5)
+        inner(item)
+
+    sink._worker.handler = gated
+    return entered, gate
+
+
+def read_events(db_path):
+    con = sqlite3.connect(db_path)
+    try:
+        return [row[0] for row in con.execute("SELECT event FROM events ORDER BY id")]
+    finally:
+        con.close()
 
 
 def test_sqlite_event_sink_persists_config_and_events(tmp_path):
@@ -88,3 +122,108 @@ def test_sqlite_event_sink_disabled_without_path():
     assert sink.enabled is False
     assert sink.write("event") is False
     assert sink.stats.submitted == 0
+
+
+def test_sqlite_sink_critical_events_survive_queue_pressure(tmp_path):
+    db_path = tmp_path / "pressure.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-pressure", queue_size=1)
+    assert wait_until(lambda: sink.stats.processed >= 1)
+    entered, gate = gate_worker(sink)
+
+    assert sink.write("tick", seq=1)
+    assert entered.wait(timeout=2)
+    assert sink.write("tick", seq=2)
+    assert sink.write("tick", seq=3) is False
+    assert sink.write("order_result", seq=4)
+    assert sink.write("audit", critical=True, seq=5)
+
+    gate.set()
+    sink.close()
+
+    events = read_events(db_path)
+    assert "order_result" in events
+    assert "audit" in events
+    assert events.count("tick") == 2
+    assert sink.dropped_by_event == {"tick": 1}
+    assert sink.stats.dropped == 1
+
+
+def test_sqlite_sink_custom_critical_events(tmp_path):
+    db_path = tmp_path / "custom.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-custom", queue_size=1, critical_events=("fill",))
+    assert wait_until(lambda: sink.stats.processed >= 1)
+    entered, gate = gate_worker(sink)
+
+    assert sink.write("tick", seq=1)
+    assert entered.wait(timeout=2)
+    assert sink.write("tick", seq=2)
+    assert sink.write("tick", seq=3) is False
+    assert sink.write("fill", size=2.0)
+
+    gate.set()
+    sink.close()
+
+    assert "fill" in read_events(db_path)
+    assert sink.dropped_by_event == {"tick": 1}
+
+
+def test_sqlite_sink_recovers_after_transient_write_failure(tmp_path):
+    db_path = tmp_path / "recover.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-recover")
+    assert wait_until(lambda: sink.stats.processed >= 1)
+
+    sink._conn.close()
+
+    assert sink.write("after_failure", ok=True)
+    assert wait_until(lambda: sink.stats.processed >= 2)
+    assert sink.stats.failed == 0
+    sink.close()
+
+    assert "after_failure" in read_events(db_path)
+
+
+def test_sqlite_sink_gives_up_poison_event_after_bounded_retries(tmp_path):
+    db_path = tmp_path / "poison.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-poison")
+    assert wait_until(lambda: sink.stats.processed >= 1)
+
+    real_ensure = sink._ensure_connection
+    failures = {"count": 0}
+
+    def flaky_ensure():
+        if failures["count"] < 3:
+            failures["count"] += 1
+            raise sqlite3.OperationalError("disk I/O error")
+        return real_ensure()
+
+    sink._ensure_connection = flaky_ensure
+
+    assert sink.write("lost_event", seq=1)
+    assert sink.write("kept_event", seq=2)
+    assert wait_until(lambda: sink.stats.failed >= 1 and sink.stats.processed >= 2)
+    sink.close()
+
+    events = read_events(db_path)
+    assert "kept_event" in events
+    assert "lost_event" not in events
+    assert sink.stats.failed == 1
+
+
+def test_sqlite_sink_close_finalizes_run_after_connection_reset(tmp_path):
+    db_path = tmp_path / "finalize.sqlite3"
+    sink = SqliteEventSink(db_path, run_id="run-finalize")
+    assert wait_until(lambda: sink.stats.processed >= 1)
+
+    sink._conn.close()
+    sink._conn = None
+    sink.close()
+
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT closed_ts_ms, dropped_events FROM runs WHERE run_id = 'run-finalize'"
+        ).fetchone()
+    finally:
+        con.close()
+    assert row[0] is not None
+    assert row[1] == 0


### PR DESCRIPTION
## Summary

Ports two live-trading-proven lessons into the runtime event pipeline (`AsyncWorker` + `SqliteEventSink`).

**1. Money-path events are never dropped under queue pressure.** Losing an orderbook tick degrades analytics; losing an order record corrupts the ledger. `AsyncWorker.submit(item, critical=True)` routes items to an unbounded critical lane drained before the bounded queue — never dropped, never blocking the hot path, and still flushed on `close(drain=False)`. `SqliteEventSink` gains a `critical_events` constructor param (default `("order_result",)`) and a `critical` kwarg on `write()`; `order_result_hook` and `OrderPipeline.emit_result` submit order results as critical, so the guarantee holds end-to-end from hook emission to sqlite row.

**2. The writer survives sqlite errors instead of going permanently dark.** Previously the sink cached its connection; one broken connection meant every subsequent event failed forever with a per-event stdout print while the process kept trading. Now `_handle_event` serializes once, then retries connect+insert+commit up to 3 attempts with the cached connection reset between attempts; only then is the poison event surfaced and dropped, loudly, with escalating stderr cadence. `_close_connection` reconnects if needed so the runs row always gets `closed_ts_ms`/`dropped_events`.

Also: per-event-name drop counters with escalating stderr logs (1st, then every 1000th, with top offenders), a `dropped_by_event` property, and `WorkerStats.critical_pending` for observability of critical-lane buildup.

All additions are keyword-only with safe defaults; regular-path semantics are unchanged.

## Testing

- Full suite: 349 passed, 11 skipped; `mypy` clean; `ruff check` / `ruff format --check` clean
- 9 new tests (critical lane bypasses full queue, idle wakeup, drain=False flush, queue-pressure survival, custom critical events, transient-failure recovery, poison-event bounded retries, close-after-reset finalization, end-to-end hook pinning)
- The end-to-end hook test is mutation-checked: it fails if `critical=True` is reverted in `emit_result`
- Adversarial concurrency review of the committed code (lost-wakeup interleavings, sentinel/close paths, task_done accounting, retry-loop connection state); new tests ran 20/20 without flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)