### PR TITLE
Remove stale docs.html rewrite from Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Copy SKILL.md to website folder
         run: cp SKILL.md website/SKILL.md
 
-      - name: Update asset paths
-        run: sed -i 's|\.\./assets/|assets/|g' website/index.html website/docs.html
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Every push-to-main "Deploy to GitHub Pages" run fails at the "Update asset paths" step with `sed: can't read website/docs.html: No such file or directory` — the docs page was removed from `website/` some time ago, and the only remaining reference in the repo is this workflow line. The last successful production deploy was 2026-02-07, so drmanhattan.xyz (served by GitHub Pages) has been serving five-month-old content.

`website/index.html` contains zero `../assets/` references, so the sed rewrite is a no-op for the file that does exist. Remove the step entirely rather than patch its argument list.

## Verification

- `git grep docs.html` on main: only hit is this workflow line
- `grep -c '\.\./assets/' website/index.html` → 0
- After merge, the push-triggered Pages run should go green and the live site should match `website/index.html` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)