### PR TITLE
Add live QA lane: E2B-sandboxed venue checks with a keyless credential model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,12 @@ PREDICTFUN_PRIVATE_KEY=0x...your-privy-wallet-private-key
 # 2. Smart Wallet mode (PREDICTFUN_USE_SMART_WALLET=true):
 PREDICTFUN_SMART_WALLET_OWNER_PRIVATE_KEY=0x...your-smart-wallet-owner-private-key # derive this from https://predict.fun/account/settings
 PREDICTFUN_SMART_WALLET_ADDRESS=0x...your-deposit-address # derive this from https://predict.fun/account/deposit
+
+# Live QA (scripts/qa/ - see wiki/security/key-management.md)
+# QA environments are keyless by contract: the QA driver refuses to run if any
+# production key above is set. Only Kalshi DEMO credentials (mock funds, made at
+# https://demo.kalshi.co - separate from production) may be present, under these
+# deliberately distinct names. Store them in 1Password (vault: dr-manhattan-qa)
+# and inject via `op run` locally or OP_SERVICE_ACCOUNT_TOKEN in CI.
+# KALSHI_QA_DEMO_API_KEY_ID=your-demo-api-key-id
+# KALSHI_QA_DEMO_PRIVATE_KEY_PEM="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"

--- a/.github/workflows/qa-live.yml
+++ b/.github/workflows/qa-live.yml
@@ -54,6 +54,10 @@ jobs:
       HAS_DEMO_FALLBACK: ${{ secrets.KALSHI_QA_DEMO_API_KEY_ID != '' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The QA payload runs inside the sandbox, not from this checkout; never
+          # leave the runner's token sitting in .git/config for checked-out code.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -93,16 +97,22 @@ jobs:
           QA_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }}
           QA_GIT_REF: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
           QA_TIERS: ${{ inputs.tiers || 'tier1,tier2' }}
-        run: uv run --with e2b python scripts/qa/spawn_qa_sandbox.py
+        run: uv run --with 'e2b==2.34.*' python scripts/qa/spawn_qa_sandbox.py
 
       # Keyless degraded mode so the lane still verifies public reads before an
-      # E2B account is configured. Runs the checked-out code directly.
+      # E2B account is configured. Deliberately NOT run for pull_request events:
+      # this step executes the checked-out code on the runner, and PR code must
+      # only ever run inside the sandbox isolation boundary.
       - name: Run tier1 directly (no E2B configured)
-        if: env.HAS_E2B != 'true'
+        if: env.HAS_E2B != 'true' && github.event_name != 'pull_request'
         run: |
           echo "::notice::E2B_API_KEY not configured - running keyless tier1 directly on the runner."
           uv sync
           uv run python scripts/qa/run_live_qa.py --tiers tier1 --json-out qa-report.json
+
+      - name: Note skipped PR run (no E2B configured)
+        if: env.HAS_E2B != 'true' && github.event_name == 'pull_request'
+        run: echo "::warning::qa-live label set but E2B_API_KEY is not configured; PR code is only executed inside the sandbox, so nothing was run."
 
       - name: Upload QA report
         if: always()
@@ -130,9 +140,15 @@ jobs:
               body += `No qa-report.json produced (${e.message}). See the run log.\n`;
             }
             body += `\n[Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            } catch (e) {
+              // Fork PRs get a read-only token, so commenting 403s; the report is
+              // still in the artifact and step summary. Never fail the job on this.
+              core.warning(`Could not comment on the PR (${e.message}); see the artifact/step summary.`);
+            }

--- a/.github/workflows/qa-live.yml
+++ b/.github/workflows/qa-live.yml
@@ -1,0 +1,138 @@
+# Live QA (E2B sandbox)
+#
+# Runs scripts/qa/run_live_qa.py against the real venues from inside an
+# egress-firewalled E2B sandbox (deny-all + explicit allowlist), so that
+# semi-trusted code (PR branches, agent-authored changes) can be exercised
+# against live APIs without host access and without real trading secrets.
+#
+# Tiers (see wiki/security/key-management.md for the credential model):
+#   tier1 - public keyless reads across venues
+#   tier2 - order lifecycle on Kalshi's DEMO environment (mock funds only)
+#
+# Triggers:
+#   - nightly on main (after Contract Drift at 13:00 UTC)
+#   - manual dispatch (choose tiers / ref)
+#   - PRs: a maintainer applies the `qa-live` label; re-apply to re-run.
+#     Fork PRs receive no secrets, so the sandbox step skips there.
+#
+# Secret tiers:
+#   E2B_API_KEY                    runner-side only; never enters the sandbox
+#   OP_SERVICE_ACCOUNT_TOKEN       1Password service account (preferred source of
+#                                  demo credentials: vault dr-manhattan-qa)
+#   KALSHI_QA_DEMO_*               plain GitHub-secret fallback for the same
+#   (production trading secrets are never referenced by this workflow; the QA
+#    driver additionally refuses to run if any are present)
+
+name: QA Live
+
+on:
+  schedule:
+    - cron: "30 14 * * *" # daily, after the 13:00 UTC contract-drift run
+  workflow_dispatch:
+    inputs:
+      tiers:
+        description: "Tiers to run (tier1 | tier1,tier2)"
+        required: false
+        default: "tier1,tier2"
+      ref:
+        description: "Git ref to QA (default: the triggering ref)"
+        required: false
+        default: ""
+  pull_request:
+    types: [labeled]
+
+jobs:
+  qa-live:
+    if: github.event_name != 'pull_request' || github.event.label.name == 'qa-live'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      HAS_E2B: ${{ secrets.E2B_API_KEY != '' }}
+      HAS_OP: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN != '' }}
+      HAS_DEMO_FALLBACK: ${{ secrets.KALSHI_QA_DEMO_API_KEY_ID != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # Preferred credential source: 1Password service account scoped to the
+      # dr-manhattan-qa vault (demo credentials only - mock funds).
+      - name: Load demo credentials from 1Password
+        if: env.HAS_OP == 'true'
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          KALSHI_QA_DEMO_API_KEY_ID: op://dr-manhattan-qa/kalshi-demo/api-key-id
+          KALSHI_QA_DEMO_PRIVATE_KEY_PEM: op://dr-manhattan-qa/kalshi-demo/private-key-pem
+
+      - name: Load demo credentials from GitHub secrets (fallback)
+        if: env.HAS_OP != 'true' && env.HAS_DEMO_FALLBACK == 'true'
+        env:
+          KEY_ID: ${{ secrets.KALSHI_QA_DEMO_API_KEY_ID }}
+          KEY_PEM: ${{ secrets.KALSHI_QA_DEMO_PRIVATE_KEY_PEM }}
+        run: |
+          {
+            echo "KALSHI_QA_DEMO_API_KEY_ID=$KEY_ID"
+            echo "KALSHI_QA_DEMO_PRIVATE_KEY_PEM<<__PEM_EOF__"
+            echo "$KEY_PEM"
+            echo "__PEM_EOF__"
+          } >> "$GITHUB_ENV"
+
+      - name: Run live QA inside E2B sandbox
+        if: env.HAS_E2B == 'true'
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          QA_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }}
+          QA_GIT_REF: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+          QA_TIERS: ${{ inputs.tiers || 'tier1,tier2' }}
+        run: uv run --with e2b python scripts/qa/spawn_qa_sandbox.py
+
+      # Keyless degraded mode so the lane still verifies public reads before an
+      # E2B account is configured. Runs the checked-out code directly.
+      - name: Run tier1 directly (no E2B configured)
+        if: env.HAS_E2B != 'true'
+        run: |
+          echo "::notice::E2B_API_KEY not configured - running keyless tier1 directly on the runner."
+          uv sync
+          uv run python scripts/qa/run_live_qa.py --tiers tier1 --json-out qa-report.json
+
+      - name: Upload QA report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-report
+          path: qa-report.json
+          if-no-files-found: ignore
+
+      - name: Comment report on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '## Live QA report\n\n';
+            try {
+              const report = JSON.parse(fs.readFileSync('qa-report.json', 'utf8'));
+              body += report.passed ? 'Result: **PASSED**\n\n' : 'Result: **FAILED**\n\n';
+              body += '| check | status | detail |\n|---|---|---|\n';
+              for (const c of report.checks) {
+                body += `| \`${c.name}\` | ${c.status} | ${(c.detail || '').replace(/\|/g, '\\|')} |\n`;
+              }
+            } catch (e) {
+              body += `No qa-report.json produced (${e.message}). See the run log.\n`;
+            }
+            body += `\n[Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/scripts/qa/run_live_qa.py
+++ b/scripts/qa/run_live_qa.py
@@ -1,0 +1,407 @@
+"""Live QA driver: proves the unified contract against real venue behavior.
+
+Complements scripts/contract_drift_check.py (public read/parse drift) with the
+half it cannot cover: the authenticated order lifecycle. Two tiers:
+
+  tier1  Public reads across venues, zero credentials: fetch_markets through the
+         real client classes and check unified-model invariants.
+  tier2  Order lifecycle against Kalshi's DEMO environment (mock funds, separate
+         credentials): auth probe, place a resting 1-cent limit order, verify it
+         is open, cancel it, verify it is cancelled.
+
+Safety model - enforced structurally, not by prompt or convention:
+  - QA environments are keyless by contract. This driver REFUSES to start if any
+    production-shaped trading secret (raw private keys, builder secrets) is present
+    in its environment.
+  - tier2 uses KALSHI_QA_DEMO_* variables, deliberately distinct names from the
+    production KALSHI_* variables, and pins the client to the demo host.
+  - Designed to run inside an egress-firewalled E2B sandbox (see
+    scripts/qa/spawn_qa_sandbox.py and wiki/security/key-management.md); running it
+    directly also works and is exactly as keyless.
+
+    uv run python scripts/qa/run_live_qa.py --tiers tier1
+    uv run python scripts/qa/run_live_qa.py --tiers tier1,tier2 --json-out qa-report.json
+
+Exit code 0 = every attempted check passed (skips are not failures); 1 otherwise.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from dr_manhattan import Kalshi, OrderSide, OrderStatus, create_exchange
+
+# Venues probed by tier1. Two are excluded from the default set:
+#   - opinion: its API lives on a non-standard port (proxy.opinion.trade:8443) that
+#     domain-based sandbox egress rules cannot express (they cover ports 80/443 only).
+#   - predictfun: requires an API key for ALL calls, including market reads
+#     (verified live 2026-07-18), so it cannot participate in a keyless tier.
+# Both can be requested explicitly with --venues in environments that support them.
+DEFAULT_TIER1_VENUES = ["polymarket", "kalshi", "limitless"]
+
+# Production-shaped secrets that must never be present in a QA environment. The
+# point of the QA lane is that nothing in it can move real money; finding one of
+# these set is a configuration error worth failing loudly on.
+FORBIDDEN_PRODUCTION_ENV = (
+    "POLYMARKET_PRIVATE_KEY",
+    "BUILDER_SECRET",
+    "OPINION_PRIVATE_KEY",
+    "LIMITLESS_PRIVATE_KEY",
+    "PREDICTFUN_PRIVATE_KEY",
+    "PREDICTFUN_SMART_WALLET_OWNER_PRIVATE_KEY",
+    "KALSHI_PRIVATE_KEY_PEM",
+    "KALSHI_PRIVATE_KEY_PATH",
+)
+
+MARKET_SAMPLE = 5
+ORDER_POLL_ATTEMPTS = 10
+ORDER_POLL_INTERVAL_S = 1.0
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str  # "pass" | "fail" | "skip"
+    detail: str = ""
+    duration_s: float = 0.0
+
+
+@dataclass
+class QAReport:
+    checks: List[CheckResult] = field(default_factory=list)
+
+    def add(self, name: str, status: str, detail: str = "", duration_s: float = 0.0) -> None:
+        self.checks.append(CheckResult(name, status, detail, duration_s))
+        marker = {"pass": "ok", "fail": "FAIL", "skip": "skip"}[status]
+        suffix = f" ({duration_s:.1f}s)" if duration_s else ""
+        line = f"  [{marker}] {name}{suffix}"
+        if detail:
+            line += f": {detail}"
+        print(line, flush=True)
+
+    @property
+    def failed(self) -> bool:
+        return any(c.status == "fail" for c in self.checks)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": not self.failed,
+            "checks": [
+                {
+                    "name": c.name,
+                    "status": c.status,
+                    "detail": c.detail,
+                    "duration_s": round(c.duration_s, 2),
+                }
+                for c in self.checks
+            ],
+        }
+
+
+def refuse_production_secrets() -> None:
+    present = [name for name in FORBIDDEN_PRODUCTION_ENV if os.environ.get(name)]
+    if present:
+        print(
+            "REFUSING TO RUN: production-shaped secrets present in a QA environment: "
+            + ", ".join(sorted(present))
+        )
+        print("QA environments are keyless by contract - see wiki/security/key-management.md.")
+        sys.exit(2)
+
+
+def check_market_invariants(market: Any) -> Optional[str]:
+    """Return a problem description, or None if the unified Market looks sane."""
+    if not market.id:
+        return "market with empty id"
+    if not market.outcomes:
+        return f"market {market.id} has no outcomes"
+    for outcome, price in (market.prices or {}).items():
+        if price is None:
+            continue
+        if not (-1e-9 <= float(price) <= 1 + 1e-9):
+            return f"market {market.id} outcome {outcome} price {price} outside [0, 1]"
+    if market.volume is not None and float(market.volume) < 0:
+        return f"market {market.id} negative volume {market.volume}"
+    return None
+
+
+def run_tier1(report: QAReport, venues: List[str]) -> None:
+    print("== tier1: public reads (keyless) ==", flush=True)
+    for venue in venues:
+        started = time.monotonic()
+        try:
+            # use_env=False: ambient credentials must never influence tier1 even if
+            # something leaks into the environment; validate=False: read-only client.
+            exchange = create_exchange(venue, use_env=False, verbose=False, validate=False)
+            markets = exchange.fetch_markets()
+        except Exception as exc:
+            report.add(
+                f"tier1.{venue}.fetch_markets",
+                "fail",
+                f"{type(exc).__name__}: {exc}",
+                time.monotonic() - started,
+            )
+            continue
+
+        duration = time.monotonic() - started
+        if not markets:
+            report.add(f"tier1.{venue}.fetch_markets", "fail", "returned 0 markets", duration)
+            continue
+
+        problem = None
+        for market in markets[:MARKET_SAMPLE]:
+            problem = check_market_invariants(market)
+            if problem:
+                break
+        if problem:
+            report.add(f"tier1.{venue}.invariants", "fail", problem, duration)
+        else:
+            report.add(
+                f"tier1.{venue}.fetch_markets",
+                "pass",
+                f"{len(markets)} markets, {min(len(markets), MARKET_SAMPLE)} sampled clean",
+                duration,
+            )
+
+
+def build_demo_kalshi() -> Optional[Kalshi]:
+    api_key_id = os.environ.get("KALSHI_QA_DEMO_API_KEY_ID", "").strip()
+    private_key_pem = os.environ.get("KALSHI_QA_DEMO_PRIVATE_KEY_PEM", "").strip()
+    if not api_key_id or not private_key_pem:
+        return None
+    # Support single-line PEM values with literal \n separators (the .env.example
+    # convention for KALSHI_PRIVATE_KEY_PEM).
+    if "\\n" in private_key_pem and "\n" not in private_key_pem:
+        private_key_pem = private_key_pem.replace("\\n", "\n")
+    return Kalshi(
+        {
+            "api_key_id": api_key_id,
+            "private_key_pem": private_key_pem,
+            "demo": True,
+            "verbose": False,
+        }
+    )
+
+
+def poll_order_status(
+    exchange: Kalshi, order_id: str, wanted: OrderStatus
+) -> Optional[OrderStatus]:
+    """Poll until the order reaches `wanted`; return the last observed status."""
+    last: Optional[OrderStatus] = None
+    for _ in range(ORDER_POLL_ATTEMPTS):
+        order = exchange.fetch_order(order_id)
+        last = order.status
+        if last == wanted:
+            return last
+        # Terminal states other than the wanted one will not change; stop early.
+        if last in (OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.REJECTED):
+            return last
+        time.sleep(ORDER_POLL_INTERVAL_S)
+    return last
+
+
+def run_tier2(report: QAReport) -> None:
+    print("== tier2: Kalshi demo order lifecycle (mock funds) ==", flush=True)
+    exchange = build_demo_kalshi()
+    if exchange is None:
+        report.add(
+            "tier2.kalshi_demo",
+            "skip",
+            "KALSHI_QA_DEMO_API_KEY_ID / KALSHI_QA_DEMO_PRIVATE_KEY_PEM not set",
+        )
+        return
+
+    # Structural pin: whatever else happens, tier2 only ever talks to the demo host.
+    api_url = getattr(exchange, "_api_url", "")
+    if "demo-api.kalshi.co" not in api_url:
+        report.add("tier2.demo_host_pin", "fail", f"client resolved to non-demo host: {api_url}")
+        return
+
+    started = time.monotonic()
+    try:
+        balance = exchange.fetch_balance()
+    except Exception as exc:
+        report.add(
+            "tier2.auth_probe",
+            "fail",
+            f"fetch_balance raised {type(exc).__name__}: {exc}",
+            time.monotonic() - started,
+        )
+        return
+    report.add(
+        "tier2.auth_probe",
+        "pass",
+        f"demo balance keys: {sorted(balance.keys())}",
+        time.monotonic() - started,
+    )
+
+    started = time.monotonic()
+    try:
+        markets = exchange.fetch_markets()
+    except Exception as exc:
+        report.add(
+            "tier2.fetch_markets",
+            "fail",
+            f"{type(exc).__name__}: {exc}",
+            time.monotonic() - started,
+        )
+        return
+    # A 1-cent buy can only rest (not fill) if the market's Yes side trades well
+    # above it; require a mid of at least 5 cents and some volume.
+    candidates = [
+        m
+        for m in markets
+        if float(m.prices.get("Yes", 0) or 0) >= 0.05 and float(m.volume or 0) > 0
+    ]
+    if not candidates:
+        report.add("tier2.pick_market", "skip", "no liquid open demo market found")
+        return
+    market = max(candidates, key=lambda m: float(m.volume or 0))
+    report.add(
+        "tier2.pick_market",
+        "pass",
+        f"{market.id} (Yes mid {market.prices.get('Yes'):.2f}, volume {market.volume:.0f})",
+        time.monotonic() - started,
+    )
+
+    started = time.monotonic()
+    try:
+        order = exchange.create_order(
+            market_id=market.id,
+            outcome="Yes",
+            side=OrderSide.BUY,
+            price=0.01,
+            size=1,
+        )
+    except Exception as exc:
+        report.add(
+            "tier2.create_order",
+            "fail",
+            f"{type(exc).__name__}: {exc}",
+            time.monotonic() - started,
+        )
+        return
+    report.add(
+        "tier2.create_order",
+        "pass",
+        f"order {order.id} on {market.id} @ 0.01 x1",
+        time.monotonic() - started,
+    )
+
+    started = time.monotonic()
+    status = poll_order_status(exchange, order.id, OrderStatus.OPEN)
+    if status == OrderStatus.FILLED:
+        # Mock funds, 1 cent, 1 contract: harmless, but the resting-order half of the
+        # lifecycle was not exercised. Report honestly rather than pretending.
+        report.add(
+            "tier2.order_open",
+            "pass",
+            "order filled immediately at 0.01 on demo (harmless; cancel path not exercised)",
+            time.monotonic() - started,
+        )
+        return
+    if status != OrderStatus.OPEN:
+        report.add(
+            "tier2.order_open",
+            "fail",
+            f"order {order.id} never showed open; last status: {status}",
+            time.monotonic() - started,
+        )
+        return
+    report.add("tier2.order_open", "pass", f"order {order.id} resting", time.monotonic() - started)
+
+    started = time.monotonic()
+    try:
+        exchange.cancel_order(order.id)
+    except Exception as exc:
+        report.add(
+            "tier2.cancel_order",
+            "fail",
+            f"{type(exc).__name__}: {exc} - demo order {order.id} may still be resting",
+            time.monotonic() - started,
+        )
+        return
+    status = poll_order_status(exchange, order.id, OrderStatus.CANCELLED)
+    if status == OrderStatus.CANCELLED:
+        report.add(
+            "tier2.cancel_order", "pass", f"order {order.id} cancelled", time.monotonic() - started
+        )
+    else:
+        report.add(
+            "tier2.cancel_order",
+            "fail",
+            f"cancel accepted but last status: {status}",
+            time.monotonic() - started,
+        )
+
+    try:
+        open_orders = exchange.fetch_open_orders(market_id=market.id)
+        leftovers = [o.id for o in open_orders if o.id == order.id]
+        if leftovers:
+            report.add("tier2.no_leftover_orders", "fail", f"order still open: {leftovers}")
+        else:
+            report.add("tier2.no_leftover_orders", "pass", "no leftover QA orders")
+    except Exception as exc:
+        report.add("tier2.no_leftover_orders", "skip", f"could not verify: {exc}")
+
+
+def write_github_step_summary(report: QAReport) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    lines = ["## Live QA report", "", "| check | status | detail |", "|---|---|---|"]
+    for c in report.checks:
+        detail = c.detail.replace("|", "\\|")
+        lines.append(f"| `{c.name}` | {c.status} | {detail} |")
+    lines.append("")
+    lines.append("PASSED" if not report.failed else "FAILED")
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--tiers",
+        default="tier1",
+        help="comma-separated tiers to run: tier1,tier2 (default: tier1)",
+    )
+    parser.add_argument(
+        "--venues",
+        default=",".join(DEFAULT_TIER1_VENUES),
+        help=f"comma-separated tier1 venues (default: {','.join(DEFAULT_TIER1_VENUES)})",
+    )
+    parser.add_argument("--json-out", default="", help="write the JSON report to this path")
+    args = parser.parse_args()
+
+    refuse_production_secrets()
+
+    tiers = {t.strip() for t in args.tiers.split(",") if t.strip()}
+    unknown = tiers - {"tier1", "tier2"}
+    if unknown:
+        parser.error(f"unknown tiers: {sorted(unknown)}")
+    venues = [v.strip().lower() for v in args.venues.split(",") if v.strip()]
+
+    report = QAReport()
+    if "tier1" in tiers:
+        run_tier1(report, venues)
+    if "tier2" in tiers:
+        run_tier2(report)
+
+    write_github_step_summary(report)
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(report.to_dict(), fh, indent=2)
+
+    if report.failed:
+        print("\nLive QA FAILED - at least one check failed.")
+        sys.exit(1)
+    print("\nLive QA passed - all attempted checks succeeded.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qa/run_live_qa.py
+++ b/scripts/qa/run_live_qa.py
@@ -48,7 +48,12 @@ DEFAULT_TIER1_VENUES = ["polymarket", "kalshi", "limitless"]
 # these set is a configuration error worth failing loudly on.
 FORBIDDEN_PRODUCTION_ENV = (
     "POLYMARKET_PRIVATE_KEY",
+    # The operator key signs on behalf of every user who approved the operator -
+    # the highest-blast-radius credential in the codebase (polymarket_operator.py).
+    "POLYMARKET_OPERATOR_KEY",
+    "BUILDER_API_KEY",
     "BUILDER_SECRET",
+    "BUILDER_PASS_PHRASE",
     "OPINION_PRIVATE_KEY",
     "LIMITLESS_PRIVATE_KEY",
     "PREDICTFUN_PRIVATE_KEY",
@@ -168,19 +173,23 @@ def run_tier1(report: QAReport, venues: List[str]) -> None:
             )
 
 
+def normalize_pem(pem: str) -> str:
+    """Expand single-line PEM values that use literal \\n separators (the
+    .env.example convention for KALSHI_PRIVATE_KEY_PEM)."""
+    if "\\n" in pem and "\n" not in pem:
+        return pem.replace("\\n", "\n")
+    return pem
+
+
 def build_demo_kalshi() -> Optional[Kalshi]:
     api_key_id = os.environ.get("KALSHI_QA_DEMO_API_KEY_ID", "").strip()
     private_key_pem = os.environ.get("KALSHI_QA_DEMO_PRIVATE_KEY_PEM", "").strip()
     if not api_key_id or not private_key_pem:
         return None
-    # Support single-line PEM values with literal \n separators (the .env.example
-    # convention for KALSHI_PRIVATE_KEY_PEM).
-    if "\\n" in private_key_pem and "\n" not in private_key_pem:
-        private_key_pem = private_key_pem.replace("\\n", "\n")
     return Kalshi(
         {
             "api_key_id": api_key_id,
-            "private_key_pem": private_key_pem,
+            "private_key_pem": normalize_pem(private_key_pem),
             "demo": True,
             "verbose": False,
         }
@@ -190,10 +199,23 @@ def build_demo_kalshi() -> Optional[Kalshi]:
 def poll_order_status(
     exchange: Kalshi, order_id: str, wanted: OrderStatus
 ) -> Optional[OrderStatus]:
-    """Poll until the order reaches `wanted`; return the last observed status."""
+    """Poll until the order reaches `wanted`; return the last observed status.
+
+    Transient fetch errors (one 5xx or timeout mid-poll) are tolerated so a blip
+    between create and cancel cannot crash the lifecycle mid-flight; run_tier2's
+    cleanup relies on this function returning normally.
+    """
     last: Optional[OrderStatus] = None
+    errors = 0
     for _ in range(ORDER_POLL_ATTEMPTS):
-        order = exchange.fetch_order(order_id)
+        try:
+            order = exchange.fetch_order(order_id)
+        except Exception:
+            errors += 1
+            if errors >= ORDER_POLL_ATTEMPTS:
+                return last
+            time.sleep(ORDER_POLL_INTERVAL_S)
+            continue
         last = order.status
         if last == wanted:
             return last
@@ -292,61 +314,94 @@ def run_tier2(report: QAReport) -> None:
         time.monotonic() - started,
     )
 
-    started = time.monotonic()
-    status = poll_order_status(exchange, order.id, OrderStatus.OPEN)
-    if status == OrderStatus.FILLED:
-        # Mock funds, 1 cent, 1 contract: harmless, but the resting-order half of the
-        # lifecycle was not exercised. Report honestly rather than pretending.
-        report.add(
-            "tier2.order_open",
-            "pass",
-            "order filled immediately at 0.01 on demo (harmless; cancel path not exercised)",
-            time.monotonic() - started,
-        )
-        return
-    if status != OrderStatus.OPEN:
-        report.add(
-            "tier2.order_open",
-            "fail",
-            f"order {order.id} never showed open; last status: {status}",
-            time.monotonic() - started,
-        )
-        return
-    report.add("tier2.order_open", "pass", f"order {order.id} resting", time.monotonic() - started)
-
-    started = time.monotonic()
+    # From here on the demo book may hold our resting order. Whatever path the
+    # checks take (including unexpected exceptions), leave through the cleanup
+    # below so QA never strands an order until market expiry.
+    order_resolved = False
     try:
-        exchange.cancel_order(order.id)
-    except Exception as exc:
+        started = time.monotonic()
+        status = poll_order_status(exchange, order.id, OrderStatus.OPEN)
+        if status == OrderStatus.FILLED:
+            # Mock funds, 1 cent, 1 contract: harmless, but the resting-order half
+            # of the lifecycle was not exercised. Report honestly.
+            order_resolved = True
+            report.add(
+                "tier2.order_open",
+                "pass",
+                "order filled immediately at 0.01 on demo (harmless; cancel path not exercised)",
+                time.monotonic() - started,
+            )
+            return
+        if status != OrderStatus.OPEN:
+            report.add(
+                "tier2.order_open",
+                "fail",
+                f"order {order.id} never showed open; last status: {status}",
+                time.monotonic() - started,
+            )
+            return
         report.add(
-            "tier2.cancel_order",
-            "fail",
-            f"{type(exc).__name__}: {exc} - demo order {order.id} may still be resting",
-            time.monotonic() - started,
-        )
-        return
-    status = poll_order_status(exchange, order.id, OrderStatus.CANCELLED)
-    if status == OrderStatus.CANCELLED:
-        report.add(
-            "tier2.cancel_order", "pass", f"order {order.id} cancelled", time.monotonic() - started
-        )
-    else:
-        report.add(
-            "tier2.cancel_order",
-            "fail",
-            f"cancel accepted but last status: {status}",
-            time.monotonic() - started,
+            "tier2.order_open", "pass", f"order {order.id} resting", time.monotonic() - started
         )
 
-    try:
-        open_orders = exchange.fetch_open_orders(market_id=market.id)
-        leftovers = [o.id for o in open_orders if o.id == order.id]
-        if leftovers:
-            report.add("tier2.no_leftover_orders", "fail", f"order still open: {leftovers}")
+        started = time.monotonic()
+        try:
+            exchange.cancel_order(order.id)
+        except Exception as exc:
+            report.add(
+                "tier2.cancel_order",
+                "fail",
+                f"{type(exc).__name__}: {exc} - demo order {order.id} may still be resting",
+                time.monotonic() - started,
+            )
+            return
+        status = poll_order_status(exchange, order.id, OrderStatus.CANCELLED)
+        if status == OrderStatus.CANCELLED:
+            order_resolved = True
+            report.add(
+                "tier2.cancel_order",
+                "pass",
+                f"order {order.id} cancelled",
+                time.monotonic() - started,
+            )
         else:
-            report.add("tier2.no_leftover_orders", "pass", "no leftover QA orders")
-    except Exception as exc:
-        report.add("tier2.no_leftover_orders", "skip", f"could not verify: {exc}")
+            report.add(
+                "tier2.cancel_order",
+                "fail",
+                f"cancel accepted but last status: {status}",
+                time.monotonic() - started,
+            )
+
+        # Verify terminality via fetch_order: fetch_open_orders swallows errors and
+        # returns [], which would turn an API failure into a false "no leftovers".
+        try:
+            final_status = exchange.fetch_order(order.id).status
+        except Exception as exc:
+            report.add("tier2.no_leftover_orders", "skip", f"could not verify: {exc}")
+        else:
+            if final_status in (
+                OrderStatus.CANCELLED,
+                OrderStatus.FILLED,
+                OrderStatus.REJECTED,
+            ):
+                order_resolved = True
+                report.add(
+                    "tier2.no_leftover_orders", "pass", f"order terminal: {final_status.value}"
+                )
+            else:
+                order_resolved = False
+                report.add("tier2.no_leftover_orders", "fail", f"order still {final_status.value}")
+    finally:
+        if not order_resolved:
+            try:
+                exchange.cancel_order(order.id)
+                report.add("tier2.cleanup_cancel", "pass", f"best-effort cancel of {order.id} sent")
+            except Exception as exc:
+                report.add(
+                    "tier2.cleanup_cancel",
+                    "skip",
+                    f"best-effort cancel failed: {exc} (demo order {order.id} may rest until expiry)",
+                )
 
 
 def write_github_step_summary(report: QAReport) -> None:

--- a/scripts/qa/spawn_qa_sandbox.py
+++ b/scripts/qa/spawn_qa_sandbox.py
@@ -1,0 +1,193 @@
+"""Spawn an egress-firewalled E2B sandbox and run the live QA driver inside it.
+
+Runner-side half of the live QA lane (.github/workflows/qa-live.yml). The sandbox
+is the isolation boundary: semi-trusted code (a PR branch, agent-authored changes)
+executes inside a Firecracker microVM whose egress is deny-all plus an explicit
+per-tier allowlist, and the only credentials that ever enter it are Kalshi DEMO
+credentials (mock funds). E2B_API_KEY itself stays on the runner.
+
+Environment contract (all optional unless noted):
+  E2B_API_KEY                     required; consumed by the e2b SDK on the runner
+  QA_REPO_URL                     clone URL (default: this repo on GitHub)
+  QA_GIT_REF                      branch / tag / SHA to check out (default: main)
+  QA_TIERS                        forwarded to run_live_qa.py --tiers (default: tier1)
+  QA_VENUES                       forwarded to run_live_qa.py --venues when set
+  QA_FIREWALL                     strict (default) | off. "off" is an explicit
+                                  escape hatch for debugging only - it spawns with
+                                  unrestricted egress and prints a loud warning.
+  QA_SANDBOX_TIMEOUT_S            sandbox lifetime budget (default: 1800)
+  KALSHI_QA_DEMO_API_KEY_ID       demo credentials, forwarded ONLY to the QA
+  KALSHI_QA_DEMO_PRIVATE_KEY_PEM  command inside the sandbox
+
+The egress allowlist is domain-based (E2B evaluates domains for ports 80/443), so
+venues on non-standard ports (Opinion at proxy.opinion.trade:8443) are excluded
+from firewalled runs - see run_live_qa.py. Firewall semantics reference:
+https://e2b.dev/docs/sandbox/internet-access
+
+    uv run --with e2b python scripts/qa/spawn_qa_sandbox.py
+
+Exit code mirrors the in-sandbox QA driver (0 pass, 1 fail, 2 refused/config).
+"""
+
+import os
+import shlex
+import sys
+
+REPO_URL_DEFAULT = "https://github.com/guzus/dr-manhattan.git"
+REPO_DIR = "/home/user/repo"
+REPORT_PATH = f"{REPO_DIR}/qa-report.json"
+
+# Toolchain endpoints every sandbox run needs: clone the repo, install uv, let uv
+# fetch a CPython build and resolve wheels from the lockfile.
+ALLOW_TOOLCHAIN = [
+    "github.com",
+    "codeload.github.com",
+    "objects.githubusercontent.com",
+    "raw.githubusercontent.com",
+    "pypi.org",
+    "files.pythonhosted.org",
+]
+
+# tier1: public, keyless market-data reads. api.predict.fun is deliberately absent:
+# Predict.fun requires an API key even for market reads, so it is not part of the
+# keyless tier (re-add alongside a PREDICTFUN QA credential if that changes).
+ALLOW_TIER1 = [
+    "gamma-api.polymarket.com",
+    "clob.polymarket.com",
+    "data-api.polymarket.com",
+    "api.elections.kalshi.com",
+    "api.limitless.exchange",
+]
+
+# tier2: the Kalshi DEMO host only. The production Kalshi host is already present
+# via tier1 public reads; demo credentials cannot authenticate against it.
+ALLOW_TIER2 = [
+    "demo-api.kalshi.co",
+]
+
+
+def build_allowlist(tiers: str) -> list:
+    allow = list(ALLOW_TOOLCHAIN)
+    if "tier1" in tiers:
+        allow += ALLOW_TIER1
+    if "tier2" in tiers:
+        allow += ALLOW_TIER2
+    return allow
+
+
+def main() -> None:
+    if not os.environ.get("E2B_API_KEY"):
+        print("E2B_API_KEY is not set; cannot spawn a sandbox.", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from e2b import Sandbox
+    except ImportError:
+        print(
+            "The e2b SDK is not installed. Run via: uv run --with e2b python "
+            "scripts/qa/spawn_qa_sandbox.py",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    repo_url = os.environ.get("QA_REPO_URL", REPO_URL_DEFAULT)
+    git_ref = os.environ.get("QA_GIT_REF", "main")
+    tiers = os.environ.get("QA_TIERS", "tier1")
+    venues = os.environ.get("QA_VENUES", "")
+    firewall = os.environ.get("QA_FIREWALL", "strict").lower()
+    timeout_s = int(os.environ.get("QA_SANDBOX_TIMEOUT_S", "1800"))
+
+    create_kwargs = {"timeout": timeout_s}
+    if firewall == "off":
+        print("WARNING: QA_FIREWALL=off - sandbox egress is UNRESTRICTED (debug only).")
+    else:
+        allowlist = build_allowlist(tiers)
+        # Deny everything, then allow the explicit list. E2B evaluates allow rules
+        # with precedence over deny rules; domain rules cover ports 80/443.
+        create_kwargs["network"] = {
+            "deny_out": lambda ctx: [ctx.all_traffic],
+            "allow_out": allowlist,
+        }
+        print(f"Egress firewall: deny-all + allowlist ({len(allowlist)} hosts)")
+        for host in allowlist:
+            print(f"  allow {host}")
+
+    print(f"Spawning sandbox (timeout {timeout_s}s) for {repo_url} @ {git_ref} ...")
+    try:
+        sandbox = Sandbox.create(**create_kwargs)
+    except TypeError as exc:
+        # Do NOT fall back to an unfirewalled sandbox: a silent fallback would erase
+        # the guarantee this lane exists to provide. Fail loudly instead.
+        print(
+            "Sandbox.create rejected the network configuration - the installed e2b SDK "
+            f"may predate egress firewall support ({exc}). Refusing to run without the "
+            "firewall; set QA_FIREWALL=off explicitly if you need a debug run.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    exit_code = 1
+    try:
+
+        def run(cmd: str, timeout: int = 600, envs: dict = None) -> object:
+            print(f"$ {cmd}", flush=True)
+            result = sandbox.commands.run(cmd, timeout=timeout, envs=envs or {})
+            if result.stdout:
+                print(result.stdout, end="", flush=True)
+            if result.stderr:
+                print(result.stderr, end="", file=sys.stderr, flush=True)
+            return result
+
+        clone = run(
+            f"git clone --depth 50 {shlex.quote(repo_url)} {REPO_DIR} && "
+            f"cd {REPO_DIR} && (git checkout {shlex.quote(git_ref)} || "
+            f"(git fetch --depth 1 origin {shlex.quote(git_ref)} && git checkout FETCH_HEAD))"
+        )
+        if clone.exit_code != 0:
+            print("Repository checkout failed inside the sandbox.", file=sys.stderr)
+            sys.exit(1)
+
+        setup = run(
+            f"cd {REPO_DIR} && pip install --quiet uv && uv python install 3.12 && uv sync",
+            timeout=900,
+        )
+        if setup.exit_code != 0:
+            print("Dependency setup failed inside the sandbox.", file=sys.stderr)
+            sys.exit(1)
+
+        qa_cmd = (
+            f"cd {REPO_DIR} && uv run python scripts/qa/run_live_qa.py --tiers {shlex.quote(tiers)}"
+        )
+        if venues:
+            qa_cmd += f" --venues {shlex.quote(venues)}"
+        qa_cmd += f" --json-out {REPORT_PATH}"
+
+        # Demo credentials are injected only into this command's environment - they
+        # are not part of the sandbox definition and never leave this process's env.
+        qa_envs = {}
+        for name in ("KALSHI_QA_DEMO_API_KEY_ID", "KALSHI_QA_DEMO_PRIVATE_KEY_PEM"):
+            value = os.environ.get(name, "")
+            if value:
+                qa_envs[name] = value
+
+        qa = run(qa_cmd, timeout=timeout_s, envs=qa_envs)
+        exit_code = qa.exit_code
+
+        try:
+            report = sandbox.files.read(REPORT_PATH)
+            with open("qa-report.json", "w", encoding="utf-8") as fh:
+                fh.write(report)
+            print("Report written to qa-report.json")
+        except Exception as exc:
+            print(f"Could not retrieve {REPORT_PATH}: {exc}", file=sys.stderr)
+    finally:
+        try:
+            sandbox.kill()
+        except Exception:
+            pass
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qa/spawn_qa_sandbox.py
+++ b/scripts/qa/spawn_qa_sandbox.py
@@ -15,7 +15,8 @@ Environment contract (all optional unless noted):
   QA_FIREWALL                     strict (default) | off. "off" is an explicit
                                   escape hatch for debugging only - it spawns with
                                   unrestricted egress and prints a loud warning.
-  QA_SANDBOX_TIMEOUT_S            sandbox lifetime budget (default: 1800)
+  QA_SANDBOX_TIMEOUT_S            budget for the QA command itself (default: 1800;
+                                  the sandbox TTL adds clone + setup + slack on top)
   KALSHI_QA_DEMO_API_KEY_ID       demo credentials, forwarded ONLY to the QA
   KALSHI_QA_DEMO_PRIVATE_KEY_PEM  command inside the sandbox
 
@@ -24,7 +25,12 @@ venues on non-standard ports (Opinion at proxy.opinion.trade:8443) are excluded
 from firewalled runs - see run_live_qa.py. Firewall semantics reference:
 https://e2b.dev/docs/sandbox/internet-access
 
-    uv run --with e2b python scripts/qa/spawn_qa_sandbox.py
+    uv run --with 'e2b==2.34.*' python scripts/qa/spawn_qa_sandbox.py
+
+The pin matters: the network kwarg is a runtime-unvalidated TypedDict, so an SDK
+with different field names could silently drop the firewall; 2.34.x is the version
+this configuration was verified against (build_network_config compiles it to
+deny_out 0.0.0.0/0 + the allowlist).
 
 Exit code mirrors the in-sandbox QA driver (0 pass, 1 fail, 2 refused/config).
 """
@@ -36,6 +42,8 @@ import sys
 REPO_URL_DEFAULT = "https://github.com/guzus/dr-manhattan.git"
 REPO_DIR = "/home/user/repo"
 REPORT_PATH = f"{REPO_DIR}/qa-report.json"
+CLONE_TIMEOUT_S = 600
+SETUP_TIMEOUT_S = 900
 
 # Toolchain endpoints every sandbox run needs: clone the repo, install uv, let uv
 # fetch a CPython build and resolve wheels from the lockfile.
@@ -81,10 +89,10 @@ def main() -> None:
         sys.exit(2)
 
     try:
-        from e2b import Sandbox
+        from e2b import CommandExitException, Sandbox
     except ImportError:
         print(
-            "The e2b SDK is not installed. Run via: uv run --with e2b python "
+            "The e2b SDK is not installed. Run via: uv run --with 'e2b==2.34.*' python "
             "scripts/qa/spawn_qa_sandbox.py",
             file=sys.stderr,
         )
@@ -96,8 +104,11 @@ def main() -> None:
     venues = os.environ.get("QA_VENUES", "")
     firewall = os.environ.get("QA_FIREWALL", "strict").lower()
     timeout_s = int(os.environ.get("QA_SANDBOX_TIMEOUT_S", "1800"))
+    # The sandbox TTL starts at creation, so it must cover the whole clone + setup +
+    # QA sequence, not just the QA command's own budget.
+    sandbox_ttl_s = CLONE_TIMEOUT_S + SETUP_TIMEOUT_S + timeout_s + 120
 
-    create_kwargs = {"timeout": timeout_s}
+    create_kwargs = {"timeout": sandbox_ttl_s}
     if firewall == "off":
         print("WARNING: QA_FIREWALL=off - sandbox egress is UNRESTRICTED (debug only).")
     else:
@@ -129,9 +140,15 @@ def main() -> None:
     exit_code = 1
     try:
 
-        def run(cmd: str, timeout: int = 600, envs: dict = None) -> object:
+        def run(cmd: str, timeout: int = CLONE_TIMEOUT_S, envs: dict = None) -> object:
             print(f"$ {cmd}", flush=True)
-            result = sandbox.commands.run(cmd, timeout=timeout, envs=envs or {})
+            try:
+                result = sandbox.commands.run(cmd, timeout=timeout, envs=envs or {})
+            except CommandExitException as exc:
+                # The SDK raises on any non-zero exit; the exception carries the same
+                # exit_code/stdout/stderr surface. Treat it as a result so failing QA
+                # runs still reach the report-retrieval path and keep their exit code.
+                result = exc
             if result.stdout:
                 print(result.stdout, end="", flush=True)
             if result.stderr:
@@ -149,7 +166,7 @@ def main() -> None:
 
         setup = run(
             f"cd {REPO_DIR} && pip install --quiet uv && uv python install 3.12 && uv sync",
-            timeout=900,
+            timeout=SETUP_TIMEOUT_S,
         )
         if setup.exit_code != 0:
             print("Dependency setup failed inside the sandbox.", file=sys.stderr)

--- a/tests/test_qa_driver.py
+++ b/tests/test_qa_driver.py
@@ -1,0 +1,92 @@
+"""Unit tests for the pure helpers in the live QA lane (scripts/qa/).
+
+The tripwire test exists because the first review of the lane found a missing
+key (POLYMARKET_OPERATOR_KEY) - the exact regression class these guard against.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "qa"))
+
+import run_live_qa  # noqa: E402
+import spawn_qa_sandbox  # noqa: E402
+
+
+class TestTripwire:
+    def test_refuses_every_forbidden_name(self, monkeypatch):
+        for name in run_live_qa.FORBIDDEN_PRODUCTION_ENV:
+            for cleared in run_live_qa.FORBIDDEN_PRODUCTION_ENV:
+                monkeypatch.delenv(cleared, raising=False)
+            monkeypatch.setenv(name, "0xdeadbeef")
+            with pytest.raises(SystemExit) as excinfo:
+                run_live_qa.refuse_production_secrets()
+            assert excinfo.value.code == 2, name
+
+    def test_operator_key_is_forbidden(self):
+        # polymarket_operator.py signs on behalf of every approving user with this.
+        assert "POLYMARKET_OPERATOR_KEY" in run_live_qa.FORBIDDEN_PRODUCTION_ENV
+
+    def test_clean_environment_passes(self, monkeypatch):
+        for name in run_live_qa.FORBIDDEN_PRODUCTION_ENV:
+            monkeypatch.delenv(name, raising=False)
+        run_live_qa.refuse_production_secrets()  # must not raise
+
+    def test_demo_names_are_not_forbidden(self):
+        assert "KALSHI_QA_DEMO_API_KEY_ID" not in run_live_qa.FORBIDDEN_PRODUCTION_ENV
+        assert "KALSHI_QA_DEMO_PRIVATE_KEY_PEM" not in run_live_qa.FORBIDDEN_PRODUCTION_ENV
+
+
+class TestMarketInvariants:
+    @staticmethod
+    def market(**overrides):
+        base = dict(id="T-1", outcomes=["Yes", "No"], prices={"Yes": 0.4, "No": 0.6}, volume=10.0)
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_clean_market(self):
+        assert run_live_qa.check_market_invariants(self.market()) is None
+
+    def test_empty_id(self):
+        assert "empty id" in run_live_qa.check_market_invariants(self.market(id=""))
+
+    def test_no_outcomes(self):
+        assert "no outcomes" in run_live_qa.check_market_invariants(self.market(outcomes=[]))
+
+    def test_price_out_of_range(self):
+        problem = run_live_qa.check_market_invariants(self.market(prices={"Yes": 1.4}))
+        assert "outside [0, 1]" in problem
+
+    def test_negative_volume(self):
+        assert "negative volume" in run_live_qa.check_market_invariants(self.market(volume=-1))
+
+
+class TestNormalizePem:
+    def test_expands_literal_newlines(self):
+        assert run_live_qa.normalize_pem("a\\nb\\nc") == "a\nb\nc"
+
+    def test_leaves_real_newlines_alone(self):
+        assert run_live_qa.normalize_pem("a\nb") == "a\nb"
+        # Mixed content (real newlines present) is left untouched.
+        assert run_live_qa.normalize_pem("a\\nb\nc") == "a\\nb\nc"
+
+
+class TestAllowlist:
+    def test_tier1_excludes_demo_host(self):
+        allow = spawn_qa_sandbox.build_allowlist("tier1")
+        assert "demo-api.kalshi.co" not in allow
+        assert "api.elections.kalshi.com" in allow
+        assert "pypi.org" in allow
+
+    def test_tier2_adds_only_demo_host(self):
+        tier1 = set(spawn_qa_sandbox.build_allowlist("tier1"))
+        both = set(spawn_qa_sandbox.build_allowlist("tier1,tier2"))
+        assert both - tier1 == {"demo-api.kalshi.co"}
+
+    def test_keyless_tier_has_no_predictfun(self):
+        # Predict.fun requires an API key for all calls, so it cannot be reachable
+        # from the keyless tier's firewall.
+        assert "api.predict.fun" not in spawn_qa_sandbox.build_allowlist("tier1")

--- a/wiki/security/key-management.md
+++ b/wiki/security/key-management.md
@@ -99,12 +99,15 @@ Options, in ascending order of operational weight:
    dominant industry pattern for AI-agent trading: the agent holds a scoped
    API credential, the platform holds the key, and a policy engine - not the
    prompt - decides what may be signed.
-4. **Venue-native delegation** - sidestep raw keys entirely where the venue
-   allows: Polymarket's Builder/operator profile places orders with API
-   credentials (the hosted MCP server already works this way - no private key
-   server-side); Kalshi never uses an Ethereum key at all (RSA request-signing
-   key, itself movable into a signer later); Predict.fun's smart-wallet mode
-   separates the owner key from the deposit address. On-chain equivalents
+4. **Venue-native delegation** - sidestep raw keys where the venue allows:
+   Polymarket's Builder profile places orders with API credentials and holds no
+   private key. Its operator mode is NOT keyless - the hosted MCP server holds a
+   `POLYMARKET_OPERATOR_KEY` that signs on behalf of every approving user
+   (`polymarket_operator.py`), which is precisely why that key is in the QA
+   tripwire and the first candidate to move behind a remote signer. Kalshi never
+   uses an Ethereum key at all (RSA request-signing key, itself movable into a
+   signer later); Predict.fun's smart-wallet mode separates the owner key from
+   the deposit address. On-chain equivalents
    (Safe modules / session keys) can constrain an EOA's power if we ever hold
    positions in contracts.
 

--- a/wiki/security/key-management.md
+++ b/wiki/security/key-management.md
@@ -1,0 +1,161 @@
+# Key management: keyless QA now, remote signing next
+
+How dr-manhattan handles trading credentials across development, QA, and
+production - and the path to sending orders without a raw private key ever
+sitting in agent-reachable memory.
+
+## Threat model
+
+dr-manhattan executes real-money, on-chain, irreversible trades. The standing
+setup (raw Ethereum private keys and venue API secrets in a local `.env`) has a
+worst-case blast radius of direct theft with no recourse, and the project
+deliberately points agents at itself ("Run and Debug yourself PROACTIVELY"),
+runs an issue-to-PR agent loop, and exposes order placement over MCP. The two
+failure classes to engineer away:
+
+1. An agent (or any semi-trusted code: PR branch, generated strategy) runs a
+   flow that submits live orders because real credentials were reachable.
+2. Credentials exfiltrate - through a log, a prompt injection, a dependency, or
+   a compromised sandbox.
+
+Both are addressed structurally, never by prompt-level instructions.
+
+## Credential tiers
+
+| Tier | What runs | Where | Credentials present |
+|---|---|---|---|
+| 0 | lint, unit tests, build (`ci.yml`) | GitHub-hosted CI | none |
+| 1 | public live reads (`contract-drift.yml`, `qa-live.yml` tier1) | CI runner / E2B sandbox | none |
+| 2 | order lifecycle QA (`qa-live.yml` tier2) | E2B sandbox, egress-firewalled | Kalshi DEMO only (mock funds) |
+| 3 | real-money strategies | operator-controlled host, human-supervised | production keys via signer (below) |
+
+Rules that hold across tiers:
+
+- QA is keyless by contract. `scripts/qa/run_live_qa.py` refuses to start if a
+  production-shaped secret is present in its environment.
+- Demo/testnet credentials use distinct variable names (`KALSHI_QA_DEMO_*`)
+  from production (`KALSHI_*`) so the tripwire can tell them apart and a copied
+  `.env` cannot silently promote a QA run to production.
+- Tier 2 sandboxes get a deny-all egress firewall plus an explicit allowlist
+  (`scripts/qa/spawn_qa_sandbox.py`), so even a fully compromised QA payload
+  can only reach the demo venue and the package toolchain.
+- Only Kalshi (`KALSHI_DEMO=true` -> demo-api.kalshi.co) and Predict.fun
+  (`PREDICTFUN_TESTNET=true`) offer test environments today. Polymarket,
+  Opinion, and Limitless have none, so they are never part of automated
+  write-QA; their write paths are exercised only at tier 3.
+
+## Storage layer: 1Password
+
+1Password is the vault and injection mechanism for everything API-key-shaped:
+
+- **Vault layout**: `dr-manhattan-qa` holds demo/testnet credentials (the only
+  vault CI can read); `dr-manhattan-prod` holds production secrets and is never
+  granted to any automation identity.
+- **CI**: a [service account](https://developer.1password.com/docs/service-accounts/)
+  scoped to `dr-manhattan-qa`, consumed by
+  [`1password/load-secrets-action`](https://github.com/1Password/load-secrets-action)
+  in `qa-live.yml` via `op://dr-manhattan-qa/kalshi-demo/...` references.
+- **Local dev**: `op run --env-file=.env.tpl -- uv run ...` injects secrets at
+  process start without a plaintext `.env` on disk; `op://` references replace
+  raw values in the template.
+
+**What 1Password is not:** a signing service. It has no API to perform a
+signature with a stored key - any consumer (`op` CLI, SDK, Connect server)
+*releases the secret* to the calling process, so the key still materializes in
+that process's memory. The one exception proves the rule: the 1Password
+[SSH agent](https://developer.1password.com/docs/ssh/agent/) signs SSH
+challenges inside the 1Password app so the key never reaches the client - but
+it speaks only the SSH agent protocol, not arbitrary secp256k1/EIP-712 message
+signing. So: 1Password for storage and injection of API-key-class secrets,
+paired with a real signer for private keys.
+
+## Signing layer: keys that cannot be read, only asked
+
+The KMS-style goal: order flows request a *signature* from a boundary that
+holds the key; nothing on the application side can read the key itself.
+
+Options, in ascending order of operational weight:
+
+1. **Cloud KMS (DIY)** - AWS KMS supports the Ethereum curve natively
+   (`ECC_SECG_P256K1`, non-exportable, optionally imported via BYOK; GCP and
+   Azure have equivalents). Libraries such as
+   [`ethereum-kms-signer`](https://github.com/meetmangukiya/ethereum-kms-signer)
+   adapt it to web3.py-style signing. Cost is roughly $1/key/month plus
+   fractions of a cent per signature. IAM scopes who may request signatures;
+   CloudTrail logs every one.
+2. **Web3Signer (self-hosted)** -
+   [Consensys Web3Signer](https://github.com/Consensys/web3signer) is an open
+   source remote-signing microservice: the app POSTs a payload, the service
+   signs with keys backed by KMS/HSM/Vault. A ready-made "signing server" if we
+   prefer an HTTP boundary over embedding KMS calls.
+3. **Managed wallet infrastructure** - purpose-built for exactly the agent
+   use case: [Turnkey](https://www.turnkey.com/) (keys in TEEs behind a
+   programmable policy engine), [Privy](https://privy.io/) server wallets,
+   [Coinbase CDP](https://docs.cdp.coinbase.com/) server wallets / AgentKit,
+   [Fireblocks](https://www.fireblocks.com/) (MPC with quorum policies,
+   institutional weight), and since July 2026
+   [Ledger Agent Stack](https://www.coindesk.com/tech/2026/07/15/ledger-wants-ai-agents-to-manage-crypto-without-holding-your-keys)
+   ("agents propose, humans approve" with hardware enforcement). This is the
+   dominant industry pattern for AI-agent trading: the agent holds a scoped
+   API credential, the platform holds the key, and a policy engine - not the
+   prompt - decides what may be signed.
+4. **Venue-native delegation** - sidestep raw keys entirely where the venue
+   allows: Polymarket's Builder/operator profile places orders with API
+   credentials (the hosted MCP server already works this way - no private key
+   server-side); Kalshi never uses an Ethereum key at all (RSA request-signing
+   key, itself movable into a signer later); Predict.fun's smart-wallet mode
+   separates the owner key from the deposit address. On-chain equivalents
+   (Safe modules / session keys) can constrain an EOA's power if we ever hold
+   positions in contracts.
+
+## Target architecture
+
+```
+strategy / MCP tool / QA driver          (no key material, ever)
+        |
+        v
+policy proxy                             per-request checks, independent of prompts:
+  - venue + market allowlist               max notional per order and per day
+  - rate limits, kill switch               full audit log of every request
+        |
+        v
+signer backend                           KMS (phase 2) or managed TEE/MPC (phase 3)
+  - holds non-exportable keys, returns signatures only
+        |
+        v
+venue SDK / API                          receives a signed order, never a key
+```
+
+The policy proxy is the piece none of the storage tools provide and the reason
+"just put the key in 1Password" is insufficient: with a raw key, *possession
+is authorization*. With a signer + policy, authorization is a program we
+control, scoped per credential, auditable, and revocable without a key
+rotation.
+
+## Phasing
+
+- **Phase 0 (this PR)**: keyless QA lane with structural guarantees - E2B
+  egress firewall, demo-only credentials via 1Password service account,
+  production-secret tripwire in the QA driver.
+- **Phase 1**: move all API-key-class secrets (Kalshi demo + prod API keys,
+  builder profiles, OpenRouter) into 1Password; local dev switches to
+  `op run`; delete plaintext `.env` from developer machines.
+- **Phase 2**: stand up KMS-backed signing for one EOA venue (Limitless is the
+  simplest single-key integration) behind a minimal policy proxy; measure
+  latency; document the eth-account signer shim each venue SDK needs.
+- **Phase 3**: evaluate managed infrastructure (Turnkey / Privy / CDP /
+  Fireblocks) for production strategies once phase-2 latency and integration
+  seams are understood; adopt if the policy engine and custody posture beat
+  the DIY proxy.
+
+## Open integration questions
+
+- Each venue SDK (py-clob-client, opinion-clob-sdk, predict-sdk) assumes a
+  local private key today; phase 2 requires a signer-object seam per SDK, and
+  upstream support varies.
+- Polymarket order signing is EIP-712 typed data; confirm the chosen signer
+  exposes raw-digest signing (KMS does) and that py-clob-client can accept an
+  external signature.
+- Latency budget: market-making strategies sign on the hot path; a KMS
+  round-trip (~tens of ms) is fine for taker flows but needs measurement
+  against BBO-chasing quote updates.


### PR DESCRIPTION
Adds a **live QA lane** that runs venue checks inside an egress-firewalled E2B sandbox, plus the key-management design (`wiki/security/key-management.md`) for sending orders without raw private keys in agent-reachable memory.

## What this adds

| Piece | Purpose |
|---|---|
| `scripts/qa/run_live_qa.py` | tier1: keyless public reads across venues; tier2: order lifecycle (place → open → cancel → verify terminal) on Kalshi's DEMO env (mock funds). Refuses to start if any production-shaped secret is in the environment. |
| `scripts/qa/spawn_qa_sandbox.py` | Spawns an E2B Firecracker sandbox with **deny-all egress + per-tier allowlist** and runs the driver inside it. Only demo credentials ever enter the sandbox; `E2B_API_KEY` stays on the runner. |
| `.github/workflows/qa-live.yml` | Nightly (14:30 UTC), `workflow_dispatch`, and PR runs via the `qa-live` label. Demo creds via 1Password service account (`op://dr-manhattan-qa/...`) with plain-secret fallback. Posts the QA report as a PR comment + artifact. PR code executes only inside the sandbox, never on the runner. |
| `wiki/security/key-management.md` | Credential tiers, 1Password scope (vault + injection — explicitly *not* a signer), and the remote-signing roadmap (AWS KMS `ECC_SECG_P256K1` / Web3Signer / Turnkey-class TEE infra) behind a policy proxy. |
| `tests/test_qa_driver.py` | 14 unit tests: tripwire completeness (incl. `POLYMARKET_OPERATOR_KEY`), market invariants, PEM normalization, firewall allowlist tiers. |

## Safety model (structural, not prompt-level)

- QA is **keyless by contract**: the driver exits 2 if `POLYMARKET_PRIVATE_KEY`, `POLYMARKET_OPERATOR_KEY`, `BUILDER_*`, or any other production-shaped secret is present.
- tier2 uses `KALSHI_QA_DEMO_*` (deliberately distinct names) and pins the client to `demo-api.kalshi.co`.
- The sandbox firewall compiles to `deny_out: 0.0.0.0/0` + 12-host allowlist (verified through e2b 2.34.0's own `build_network_config`).
- Venue quirks honored: Predict.fun needs an API key even for reads (excluded from the keyless tier); Opinion is on port 8443 (outside domain-rule coverage); Polymarket/Opinion/Limitless have no test env, so they never participate in automated write-QA.

## Verified

- tier1 live against real venues: Polymarket 1000 / Kalshi 100 / Limitless 25 markets, invariants clean.
- Tripwire, exit codes, JSON report, step-summary output; `ruff` + `mypy` + full `pytest` (364 passed) green.
- e2b SDK surface (2.34.0): `network` kwarg shape, `CommandExitException` handling (non-zero exits keep their report + exit code).

**Not yet verified** (needs account setup): an actual sandbox spawn + tier2 demo order — the first `workflow_dispatch` run after configuring secrets proves those.

## Setup to activate

1. `E2B_API_KEY` (e2b.dev) — repo Actions secret.
2. Kalshi demo account (demo.kalshi.co) → API key; store in 1Password vault `dr-manhattan-qa`, item `kalshi-demo`, fields `api-key-id` / `private-key-pem`, and add `OP_SERVICE_ACCOUNT_TOKEN` scoped to that vault — or set `KALSHI_QA_DEMO_API_KEY_ID` / `KALSHI_QA_DEMO_PRIVATE_KEY_PEM` directly as repo secrets.
3. Optional first run: `gh workflow run qa-live.yml -f tiers=tier1,tier2`.

Phases 1–3 of the signing roadmap (1Password everywhere → KMS signer for one EOA venue behind a policy proxy → managed TEE/MPC evaluation) are laid out in the wiki doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
