### PR TITLE
Add Privy server-wallet signer (Limitless)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ OPINION_MULTI_SIG_ADDR=0xYourWalletAddress...
 
 # Limitless Trading Configuration
 LIMITLESS_PRIVATE_KEY=0x1234567890abcdef...
+# Optional: sign through a Privy server wallet instead of a raw key
+# (free tier: 50k signatures/month; key never enters this process).
+# LIMITLESS_SIGNER=privy
+# PRIVY_APP_ID=your-privy-app-id
+# PRIVY_APP_SECRET=your-privy-app-secret
+# PRIVY_WALLET_ID=your-privy-wallet-id
+# PRIVY_WALLET_ADDRESS=0xOptionalKnownAddress  # skips one wallet-lookup call
 
 # Kalshi Trading Configuration
 # Get API keys from https://kalshi.com/api

--- a/dr_manhattan/__init__.py
+++ b/dr_manhattan/__init__.py
@@ -23,6 +23,7 @@ from .base.exchange_client import (
 )
 from .base.exchange_factory import create_exchange, list_exchanges
 from .base.order_tracker import OrderEvent, OrderTracker, create_fill_logger
+from .base.signer import LocalPrivateKeySigner, PrivySigner, Signer
 from .base.strategy import Strategy
 from .cross_exchange import CrossExchangeManager, OutcomeMapping
 from .exchanges.kalshi import Kalshi
@@ -53,6 +54,9 @@ __all__ = [
     "OrderTracker",
     "OrderEvent",
     "create_fill_logger",
+    "Signer",
+    "LocalPrivateKeySigner",
+    "PrivySigner",
     "Market",
     "Order",
     "OrderSide",

--- a/dr_manhattan/base/exchange_config.py
+++ b/dr_manhattan/base/exchange_config.py
@@ -41,6 +41,9 @@ class LimitlessConfig(BaseExchangeConfig):
     """Configuration for Limitless exchange."""
 
     private_key: str = ""
+    # "" or "local" = sign with private_key in-process; "privy" = sign through a
+    # Privy server wallet built from PRIVY_* env vars (see exchange_factory).
+    signer_backend: str = ""
 
 
 @dataclass

--- a/dr_manhattan/base/exchange_factory.py
+++ b/dr_manhattan/base/exchange_factory.py
@@ -102,7 +102,34 @@ def create_exchange(
     if validate:
         _validate_config(name_lower, final_config)
 
-    return exchange_class(final_config.to_dict())
+    config_dict = final_config.to_dict()
+    _attach_signer(name_lower, final_config, config_dict)
+    return exchange_class(config_dict)
+
+
+def _attach_signer(name: str, config: ExchangeConfig, config_dict: Dict) -> None:
+    """Materialize a non-local signer backend into the exchange config.
+
+    Only Limitless accepts injected signers today (its signing lives in-repo);
+    the other venues construct signatures inside their vendor SDKs and still
+    require raw keys. See dr_manhattan/base/signer.py.
+    """
+    if name != "limitless":
+        return
+    backend = (getattr(config, "signer_backend", "") or "").lower()
+    if backend in ("", "local"):
+        return
+    if backend == "privy":
+        from .signer import PrivySigner
+
+        config_dict["signer"] = PrivySigner(
+            app_id=os.getenv("PRIVY_APP_ID", ""),
+            app_secret=os.getenv("PRIVY_APP_SECRET", ""),
+            wallet_id=os.getenv("PRIVY_WALLET_ID", ""),
+            address=os.getenv("PRIVY_WALLET_ADDRESS") or None,
+        )
+        return
+    raise ValueError(f"Unknown signer_backend for {name}: {backend!r} (use 'local' or 'privy')")
 
 
 def _get_empty_config(name: str) -> ExchangeConfig:
@@ -144,6 +171,7 @@ def _load_env_config(name: str) -> ExchangeConfig:
     elif name == "limitless":
         return LimitlessConfig(
             private_key=os.getenv("LIMITLESS_PRIVATE_KEY", ""),
+            signer_backend=os.getenv("LIMITLESS_SIGNER", ""),
         )
     elif name == "predictfun":
         return PredictFunConfig(
@@ -219,6 +247,17 @@ def _validate_config(name: str, config: ExchangeConfig) -> None:
             required["predictfun"].append("smart_wallet_owner_private_key")
         else:
             required["predictfun"].append("private_key")
+
+    # Limitless can sign through an external signer backend instead of a raw key.
+    if name == "limitless" and (getattr(config, "signer_backend", "") or "").lower() == "privy":
+        required["limitless"] = []
+        missing_privy = [
+            var
+            for var in ("PRIVY_APP_ID", "PRIVY_APP_SECRET", "PRIVY_WALLET_ID")
+            if not os.getenv(var)
+        ]
+        if missing_privy:
+            raise ValueError(f"LIMITLESS_SIGNER=privy requires env vars: {missing_privy}")
 
     # For kalshi, require either private_key_path or private_key_pem
     if name == "kalshi":

--- a/dr_manhattan/base/signer.py
+++ b/dr_manhattan/base/signer.py
@@ -30,6 +30,28 @@ def _normalize_signature(signature: str) -> str:
     return signature if signature.startswith("0x") else f"0x{signature}"
 
 
+def _stringify_uints(value: Any) -> Any:
+    """Recursively convert integer leaves to decimal strings.
+
+    EIP-712 typed data is transported as JSON, and a uint256 (e.g. a CTF
+    tokenId near 2^256) cannot survive as a bare JSON number: the receiver
+    parses it into an IEEE-754 float64 and silently loses precision, so the
+    hash - and therefore the signature - is wrong. The eth_signTypedData_v4
+    convention is that numeric values are strings (Privy's own examples
+    string-encode even chainId). bool is excluded because Python bool is an int
+    subclass but EIP-712 bools must stay JSON booleans.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _stringify_uints(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_stringify_uints(item) for item in value]
+    return value
+
+
 class Signer(ABC):
     """Produces EIP-191 and EIP-712 signatures for a single address."""
 
@@ -142,11 +164,14 @@ class PrivySigner(Signer):
         )
 
     def sign_typed_data(self, typed_data: Dict[str, Any]) -> str:
+        # Numeric leaves in domain/message MUST be JSON strings, not bare
+        # numbers - see _stringify_uints. types stays untouched (it holds
+        # {"name","type"} descriptors, no signable numerics).
         privy_typed_data = {
             "types": typed_data["types"],
             "primary_type": typed_data["primaryType"],
-            "domain": typed_data["domain"],
-            "message": typed_data["message"],
+            "domain": _stringify_uints(typed_data["domain"]),
+            "message": _stringify_uints(typed_data["message"]),
         }
         return self._rpc(
             {"method": "eth_signTypedData_v4", "params": {"typed_data": privy_typed_data}}

--- a/dr_manhattan/base/signer.py
+++ b/dr_manhattan/base/signer.py
@@ -1,0 +1,153 @@
+"""Pluggable message signers.
+
+A Signer owns exactly one job: produce Ethereum signatures for an address.
+Exchanges keep owning payload construction (EIP-712 typed data, auth messages)
+and hand the finished payload to their signer, so where the private key lives
+becomes a deployment choice instead of a code path:
+
+  - LocalPrivateKeySigner: the historical behavior - a raw key in process memory
+    via eth-account. Default when config provides ``private_key``.
+  - PrivySigner: signing delegated to a Privy server wallet over REST; the raw
+    key never enters this process. Free tier covers 50k signatures/month.
+
+Wired venues: Limitless (its signing lives fully in this repo). Polymarket,
+Opinion, and Predict.fun construct signatures inside their vendor SDKs
+(py-clob-client, opinion-clob-sdk, predict-sdk), so they still require raw keys
+until those SDKs expose a signer seam.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+import requests
+
+from .errors import AuthenticationError, ExchangeError, NetworkError
+
+PRIVY_BASE_URL = "https://api.privy.io"
+
+
+def _normalize_signature(signature: str) -> str:
+    return signature if signature.startswith("0x") else f"0x{signature}"
+
+
+class Signer(ABC):
+    """Produces EIP-191 and EIP-712 signatures for a single address."""
+
+    @property
+    @abstractmethod
+    def address(self) -> str:
+        """Checksummed 0x address the signatures verify against."""
+
+    @abstractmethod
+    def sign_personal_message(self, message: str) -> str:
+        """EIP-191 personal_sign over a text message; returns a 0x-hex signature."""
+
+    @abstractmethod
+    def sign_typed_data(self, typed_data: Dict[str, Any]) -> str:
+        """EIP-712 signature over a full typed-data message; returns 0x-hex.
+
+        ``typed_data`` uses the standard eth_signTypedData_v4 shape:
+        {"types": {...incl. EIP712Domain}, "primaryType": ..., "domain": ...,
+        "message": ...}.
+        """
+
+
+class LocalPrivateKeySigner(Signer):
+    """Signs with a raw private key held in process memory (eth-account)."""
+
+    def __init__(self, private_key: str):
+        from eth_account import Account
+
+        self._account = Account.from_key(private_key)
+
+    @property
+    def address(self) -> str:
+        return self._account.address
+
+    def sign_personal_message(self, message: str) -> str:
+        from eth_account.messages import encode_defunct
+
+        signed = self._account.sign_message(encode_defunct(text=message))
+        return _normalize_signature(signed.signature.hex())
+
+    def sign_typed_data(self, typed_data: Dict[str, Any]) -> str:
+        from eth_account.messages import encode_typed_data
+
+        signed = self._account.sign_message(encode_typed_data(full_message=typed_data))
+        return _normalize_signature(signed.signature.hex())
+
+
+class PrivySigner(Signer):
+    """Signs through a Privy server wallet; the key stays inside Privy's TEEs.
+
+    API: POST {base}/v1/wallets/{wallet_id}/rpc with HTTP basic auth
+    (app_id, app_secret) plus the ``privy-app-id`` header. Privy's typed-data
+    payload uses snake_case ``primary_type``; this class converts from the
+    standard eth_signTypedData_v4 shape used across the codebase.
+    """
+
+    def __init__(
+        self,
+        app_id: str,
+        app_secret: str,
+        wallet_id: str,
+        address: Optional[str] = None,
+        base_url: str = PRIVY_BASE_URL,
+        timeout: int = 30,
+    ):
+        if not (app_id and app_secret and wallet_id):
+            raise AuthenticationError("PrivySigner requires app_id, app_secret, and wallet_id")
+        self._wallet_id = wallet_id
+        self._address = address or ""
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._session.auth = (app_id, app_secret)
+        self._session.headers.update({"privy-app-id": app_id, "Content-Type": "application/json"})
+
+    def _request(self, method: str, path: str, body: Optional[Dict[str, Any]] = None) -> Any:
+        url = f"{self._base_url}{path}"
+        try:
+            response = self._session.request(method, url, json=body, timeout=self._timeout)
+            if response.status_code in (401, 403):
+                raise AuthenticationError(f"Privy auth failed: {response.text}")
+            response.raise_for_status()
+            return response.json()
+        except requests.Timeout as e:
+            raise NetworkError(f"Privy request timeout: {e}") from e
+        except requests.ConnectionError as e:
+            raise NetworkError(f"Privy connection error: {e}") from e
+        except requests.HTTPError as e:
+            raise ExchangeError(f"Privy HTTP error: {e}: {e.response.text[:200]}") from e
+
+    def _rpc(self, payload: Dict[str, Any]) -> str:
+        result = self._request("POST", f"/v1/wallets/{self._wallet_id}/rpc", payload)
+        signature = (result.get("data") or {}).get("signature", "")
+        if not signature:
+            raise ExchangeError(f"Privy returned no signature: {result}")
+        return _normalize_signature(signature)
+
+    @property
+    def address(self) -> str:
+        if not self._address:
+            wallet = self._request("GET", f"/v1/wallets/{self._wallet_id}")
+            self._address = wallet.get("address", "")
+            if not self._address:
+                raise ExchangeError(f"Privy wallet {self._wallet_id} has no address")
+        return self._address
+
+    def sign_personal_message(self, message: str) -> str:
+        return self._rpc(
+            {"method": "personal_sign", "params": {"message": message, "encoding": "utf-8"}}
+        )
+
+    def sign_typed_data(self, typed_data: Dict[str, Any]) -> str:
+        privy_typed_data = {
+            "types": typed_data["types"],
+            "primary_type": typed_data["primaryType"],
+            "domain": typed_data["domain"],
+            "message": typed_data["message"],
+        }
+        return self._rpc(
+            {"method": "eth_signTypedData_v4", "params": {"typed_data": privy_typed_data}}
+        )

--- a/dr_manhattan/exchanges/limitless.py
+++ b/dr_manhattan/exchanges/limitless.py
@@ -12,8 +12,6 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Sequence
 
 import requests
-from eth_account import Account
-from eth_account.messages import encode_typed_data
 
 from ..base.errors import (
     AuthenticationError,
@@ -24,6 +22,7 @@ from ..base.errors import (
     RateLimitError,
 )
 from ..base.exchange import Exchange
+from ..base.signer import LocalPrivateKeySigner, Signer
 from ..models.market import Market, parse_market_datetime
 from ..models.order import Order, OrderSide, OrderStatus, OrderTimeInForce
 from ..models.position import Position
@@ -165,7 +164,10 @@ class Limitless(Exchange):
 
         Args:
             config: Configuration dictionary with:
-                - private_key: Private key for signing transactions (required for trading)
+                - private_key: Private key for signing transactions (required for
+                  trading unless a signer is provided)
+                - signer: A dr_manhattan.base.signer.Signer instance (e.g.
+                  PrivySigner) used instead of a raw private key
                 - host: API host URL (optional, defaults to BASE_URL)
                 - chain_id: Chain ID (optional, defaults to 8453 for Base)
         """
@@ -176,7 +178,7 @@ class Limitless(Exchange):
         self.chain_id = self.config.get("chain_id", self.CHAIN_ID)
 
         self._session = requests.Session()
-        self._account = None
+        self._signer: Optional[Signer] = self.config.get("signer")
         self._address = None
         self._authenticated = False
         self._owner_id = None  # User profile ID from login response
@@ -190,15 +192,17 @@ class Limitless(Exchange):
         # Track which token IDs are "No" tokens (need inverted orderbook)
         self._no_tokens: set = set()
 
-        # Initialize account and authenticate if private key provided
-        if self.private_key:
+        # Initialize signer and authenticate if signing material was provided.
+        # An injected signer wins; a raw private_key keeps the historical path.
+        if self._signer is not None or self.private_key:
             self._initialize_auth()
 
     def _initialize_auth(self):
         """Initialize authentication with Limitless."""
         try:
-            self._account = Account.from_key(self.private_key)
-            self._address = self._account.address
+            if self._signer is None:
+                self._signer = LocalPrivateKeySigner(self.private_key)
+            self._address = self._signer.address
 
             # Authenticate with Limitless API
             self._authenticate()
@@ -218,10 +222,7 @@ class Limitless(Exchange):
                 raise AuthenticationError("Failed to get signing message")
 
             # Sign the message
-            signed = self._account.sign_message(signable_message=self._encode_defunct(message))
-            signature = signed.signature.hex()
-            if not signature.startswith("0x"):
-                signature = f"0x{signature}"
+            signature = self._signer.sign_personal_message(message)
 
             # Hex encode the signing message
             message_hex = "0x" + message.encode("utf-8").hex()
@@ -257,17 +258,11 @@ class Limitless(Exchange):
         except requests.RequestException as e:
             raise AuthenticationError(f"Authentication failed: {e}")
 
-    def _encode_defunct(self, message: str):
-        """Encode message for EIP-191 signing."""
-        from eth_account.messages import encode_defunct
-
-        return encode_defunct(text=message)
-
     def _ensure_authenticated(self):
         """Ensure user is authenticated for operations requiring auth."""
         if not self._authenticated:
             raise AuthenticationError(
-                "Not authenticated. Provide private_key in config for trading operations."
+                "Not authenticated. Provide private_key or signer in config for trading operations."
             )
 
     def _request(
@@ -297,7 +292,7 @@ class Limitless(Exchange):
 
                 if response.status_code == 401 or response.status_code == 403:
                     # Try to re-authenticate
-                    if self.private_key and self._account:
+                    if self._signer is not None:
                         self._authenticate()
                         response = self._session.request(
                             method, url, params=params, json=data, timeout=self.timeout
@@ -951,14 +946,7 @@ class Limitless(Exchange):
             "message": message,
         }
 
-        encoded = encode_typed_data(full_message=typed_data)
-        signed = self._account.sign_message(encoded)
-
-        signature = signed.signature.hex()
-        if not signature.startswith("0x"):
-            signature = "0x" + signature
-
-        return signature
+        return self._signer.sign_typed_data(typed_data)
 
     def cancel_order(self, order_id: str, market_id: Optional[str] = None) -> Order:
         """

--- a/tests/test_limitless.py
+++ b/tests/test_limitless.py
@@ -46,7 +46,7 @@ class TestLimitlessBasic:
         """Test that exchange initializes without credentials."""
         exchange = Limitless({})
         assert exchange._authenticated is False
-        assert exchange._account is None
+        assert exchange._signer is None
         assert exchange._address is None
 
     def test_ensure_authenticated_raises_without_credentials(self):
@@ -460,17 +460,17 @@ class TestLimitlessAuthenticated:
     @pytest.fixture
     def authenticated_exchange(self):
         """Create an exchange with mocked authentication."""
-        from eth_account import Account
+        from dr_manhattan.base.signer import LocalPrivateKeySigner
 
         # Use a valid test private key
         test_private_key = "0x" + "a" * 64
-        test_account = Account.from_key(test_private_key)
+        test_signer = LocalPrivateKeySigner(test_private_key)
 
         exchange = Limitless({})
         exchange._authenticated = True
         exchange._session = MagicMock()
-        exchange._account = test_account
-        exchange._address = test_account.address
+        exchange._signer = test_signer
+        exchange._address = test_signer.address
         exchange._owner_id = 12345
         return exchange
 

--- a/tests/test_signers.py
+++ b/tests/test_signers.py
@@ -1,5 +1,6 @@
 """Tests for dr_manhattan.base.signer and the Limitless signer seam."""
 
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -106,6 +107,34 @@ class TestPrivySigner(unittest.TestCase):
         self.assertEqual(typed["primary_type"], "Order")
         self.assertNotIn("primaryType", typed)
         self.assertEqual(typed["domain"]["name"], "Limitless CTF Exchange")
+
+    def test_uint256_fields_serialize_as_strings_not_bare_numbers(self):
+        # Regression: a uint256 tokenId sent as a bare JSON number is parsed
+        # into a float64 by the receiver and loses precision, corrupting the
+        # signed digest. It must go out as a decimal string.
+        big_token = 2**255 + 12345  # 78-digit uint256, far above float64 exactness
+        typed_data = {
+            "types": ORDER_TYPED_DATA["types"],
+            "primaryType": "Order",
+            "domain": {**ORDER_TYPED_DATA["domain"], "chainId": 8453},
+            "message": {"salt": 987654321987654321, "maker": "0x00", "tokenId": big_token},
+        }
+        session = MagicMock()
+        session.request.return_value = self._response(
+            {"method": "eth_signTypedData_v4", "data": {"signature": "0xok"}}
+        )
+        signer = self._make_signer(session)
+
+        signer.sign_typed_data(typed_data)
+
+        typed = session.request.call_args[1]["json"]["params"]["typed_data"]
+        self.assertEqual(typed["message"]["tokenId"], str(big_token))
+        self.assertEqual(typed["domain"]["chainId"], "8453")
+        # The actual wire bytes must preserve the value exactly - the failure
+        # mode is a float64 round-trip, so assert against the serialized JSON.
+        wire = json.dumps(session.request.call_args[1]["json"])
+        self.assertIn(f'"{big_token}"', wire)
+        self.assertNotIn(str(big_token) + ",", wire)  # never a bare numeric literal
 
     def test_sign_personal_message(self):
         session = MagicMock()

--- a/tests/test_signers.py
+++ b/tests/test_signers.py
@@ -1,0 +1,268 @@
+"""Tests for dr_manhattan.base.signer and the Limitless signer seam."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from eth_account import Account
+from eth_account.messages import encode_defunct, encode_typed_data
+
+from dr_manhattan.base.errors import AuthenticationError
+from dr_manhattan.base.exchange_config import LimitlessConfig
+from dr_manhattan.base.exchange_factory import _attach_signer, _validate_config
+from dr_manhattan.base.signer import LocalPrivateKeySigner, PrivySigner
+
+TEST_KEY = "0x" + "ab" * 32
+
+ORDER_TYPED_DATA = {
+    "types": {
+        "EIP712Domain": [
+            {"name": "name", "type": "string"},
+            {"name": "version", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+            {"name": "verifyingContract", "type": "address"},
+        ],
+        "Order": [
+            {"name": "salt", "type": "uint256"},
+            {"name": "maker", "type": "address"},
+        ],
+    },
+    "primaryType": "Order",
+    "domain": {
+        "name": "Limitless CTF Exchange",
+        "version": "1",
+        "chainId": 8453,
+        "verifyingContract": "0x0000000000000000000000000000000000000001",
+    },
+    "message": {
+        "salt": 1,
+        "maker": "0x0000000000000000000000000000000000000002",
+    },
+}
+
+
+class TestLocalPrivateKeySigner(unittest.TestCase):
+    """The local signer must be signature-identical to direct eth-account use."""
+
+    def setUp(self):
+        self.signer = LocalPrivateKeySigner(TEST_KEY)
+        self.account = Account.from_key(TEST_KEY)
+
+    def test_address_matches_eth_account(self):
+        self.assertEqual(self.signer.address, self.account.address)
+
+    def test_personal_message_parity(self):
+        expected = self.account.sign_message(encode_defunct(text="hello")).signature.hex()
+        if not expected.startswith("0x"):
+            expected = "0x" + expected
+        self.assertEqual(self.signer.sign_personal_message("hello"), expected)
+
+    def test_typed_data_parity(self):
+        encoded = encode_typed_data(full_message=ORDER_TYPED_DATA)
+        expected = self.account.sign_message(encoded).signature.hex()
+        if not expected.startswith("0x"):
+            expected = "0x" + expected
+        self.assertEqual(self.signer.sign_typed_data(ORDER_TYPED_DATA), expected)
+
+
+class TestPrivySigner(unittest.TestCase):
+    def _make_signer(self, session):
+        with patch("dr_manhattan.base.signer.requests.Session", return_value=session):
+            return PrivySigner(
+                app_id="app-1",
+                app_secret="secret-1",
+                wallet_id="wallet-1",
+                address="0x0000000000000000000000000000000000000009",
+            )
+
+    @staticmethod
+    def _response(payload, status=200):
+        response = MagicMock()
+        response.status_code = status
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        return response
+
+    def test_requires_credentials(self):
+        with self.assertRaises(AuthenticationError):
+            PrivySigner(app_id="", app_secret="s", wallet_id="w")
+
+    def test_sign_typed_data_converts_shape_and_normalizes(self):
+        session = MagicMock()
+        session.request.return_value = self._response(
+            {"method": "eth_signTypedData_v4", "data": {"signature": "abc123", "encoding": "hex"}}
+        )
+        signer = self._make_signer(session)
+
+        signature = signer.sign_typed_data(ORDER_TYPED_DATA)
+
+        self.assertEqual(signature, "0xabc123")
+        method, url = session.request.call_args[0]
+        self.assertEqual(method, "POST")
+        self.assertTrue(url.endswith("/v1/wallets/wallet-1/rpc"))
+        body = session.request.call_args[1]["json"]
+        self.assertEqual(body["method"], "eth_signTypedData_v4")
+        typed = body["params"]["typed_data"]
+        # Privy uses snake_case primary_type; everything else passes through.
+        self.assertEqual(typed["primary_type"], "Order")
+        self.assertNotIn("primaryType", typed)
+        self.assertEqual(typed["domain"]["name"], "Limitless CTF Exchange")
+
+    def test_sign_personal_message(self):
+        session = MagicMock()
+        session.request.return_value = self._response(
+            {"method": "personal_sign", "data": {"signature": "0xdef", "encoding": "hex"}}
+        )
+        signer = self._make_signer(session)
+
+        self.assertEqual(signer.sign_personal_message("login me"), "0xdef")
+        body = session.request.call_args[1]["json"]
+        self.assertEqual(body["method"], "personal_sign")
+        self.assertEqual(body["params"], {"message": "login me", "encoding": "utf-8"})
+
+    def test_auth_failure_raises(self):
+        session = MagicMock()
+        session.request.return_value = self._response({"error": "nope"}, status=401)
+        signer = self._make_signer(session)
+        with self.assertRaises(AuthenticationError):
+            signer.sign_personal_message("x")
+
+    def test_address_lazy_fetch(self):
+        session = MagicMock()
+        session.request.return_value = self._response(
+            {"id": "wallet-1", "address": "0x00000000000000000000000000000000000000AA"}
+        )
+        with patch("dr_manhattan.base.signer.requests.Session", return_value=session):
+            signer = PrivySigner(app_id="a", app_secret="s", wallet_id="wallet-1")
+
+        self.assertEqual(signer.address, "0x00000000000000000000000000000000000000AA")
+        method, url = session.request.call_args[0]
+        self.assertEqual(method, "GET")
+        self.assertTrue(url.endswith("/v1/wallets/wallet-1"))
+        # Cached: a second read must not re-fetch.
+        session.request.reset_mock()
+        _ = signer.address
+        session.request.assert_not_called()
+
+
+class _StubSigner:
+    address = "0x0000000000000000000000000000000000000123"
+
+    def __init__(self):
+        self.personal_messages = []
+        self.typed_payloads = []
+
+    def sign_personal_message(self, message):
+        self.personal_messages.append(message)
+        return "0xstub-personal"
+
+    def sign_typed_data(self, typed_data):
+        self.typed_payloads.append(typed_data)
+        return "0xstub-typed"
+
+
+class TestLimitlessSignerSeam(unittest.TestCase):
+    def _make_exchange(self, stub):
+        from dr_manhattan.exchanges.limitless import Limitless
+
+        signing_message = MagicMock()
+        signing_message.status_code = 200
+        signing_message.text = "sign this to log in"
+        signing_message.raise_for_status.return_value = None
+
+        login = MagicMock()
+        login.status_code = 200
+        login.json.return_value = {"user": {"id": "user-1"}}
+        login.raise_for_status.return_value = None
+
+        session = MagicMock()
+        session.get.return_value = signing_message
+        session.post.return_value = login
+
+        with patch("dr_manhattan.exchanges.limitless.requests.Session", return_value=session):
+            exchange = Limitless({"signer": stub, "verbose": False})
+        return exchange, session
+
+    def test_auth_uses_injected_signer(self):
+        stub = _StubSigner()
+        exchange, session = self._make_exchange(stub)
+
+        self.assertTrue(exchange._authenticated)
+        self.assertEqual(exchange._address, stub.address)
+        self.assertEqual(stub.personal_messages, ["sign this to log in"])
+        headers = session.post.call_args[1]["headers"]
+        self.assertEqual(headers["x-account"], stub.address)
+        self.assertEqual(headers["x-signature"], "0xstub-personal")
+
+    def test_order_signing_routes_through_signer(self):
+        stub = _StubSigner()
+        exchange, _ = self._make_exchange(stub)
+
+        order = {
+            "salt": 1,
+            "maker": stub.address,
+            "signer": stub.address,
+            "taker": "0x0000000000000000000000000000000000000000",
+            "tokenId": 7,
+            "makerAmount": 100,
+            "takerAmount": 100,
+            "expiration": 0,
+            "nonce": 0,
+            "feeRateBps": 300,
+            "side": 0,
+            "signatureType": 0,
+        }
+        signature = exchange._sign_order_eip712(order, "0x0000000000000000000000000000000000000001")
+
+        self.assertEqual(signature, "0xstub-typed")
+        typed = stub.typed_payloads[0]
+        self.assertEqual(typed["primaryType"], "Order")
+        self.assertEqual(typed["domain"]["name"], "Limitless CTF Exchange")
+        self.assertEqual(typed["message"]["maker"], stub.address)
+
+
+class TestFactorySignerBackend(unittest.TestCase):
+    def test_validate_privy_requires_env(self):
+        config = LimitlessConfig(signer_backend="privy")
+        empty = {"PRIVY_APP_ID": "", "PRIVY_APP_SECRET": "", "PRIVY_WALLET_ID": ""}
+        with patch.dict("os.environ", empty):
+            with self.assertRaises(ValueError) as ctx:
+                _validate_config("limitless", config)
+        self.assertIn("PRIVY_APP_ID", str(ctx.exception))
+
+    def test_validate_privy_skips_private_key_requirement(self):
+        config = LimitlessConfig(signer_backend="privy")
+        env = {
+            "PRIVY_APP_ID": "a",
+            "PRIVY_APP_SECRET": "s",
+            "PRIVY_WALLET_ID": "w",
+        }
+        with patch.dict("os.environ", env):
+            _validate_config("limitless", config)  # must not raise
+
+    def test_attach_signer_builds_privy(self):
+        config = LimitlessConfig(signer_backend="privy")
+        config_dict = config.to_dict()
+        env = {
+            "PRIVY_APP_ID": "a",
+            "PRIVY_APP_SECRET": "s",
+            "PRIVY_WALLET_ID": "w",
+            "PRIVY_WALLET_ADDRESS": "0x0000000000000000000000000000000000000042",
+        }
+        with patch.dict("os.environ", env):
+            _attach_signer("limitless", config, config_dict)
+        self.assertIsInstance(config_dict["signer"], PrivySigner)
+
+    def test_attach_signer_rejects_unknown_backend(self):
+        config = LimitlessConfig(signer_backend="ledger")
+        with self.assertRaises(ValueError):
+            _attach_signer("limitless", config, config.to_dict())
+
+    def test_attach_signer_noop_for_local(self):
+        config = LimitlessConfig(private_key=TEST_KEY)
+        config_dict = config.to_dict()
+        _attach_signer("limitless", config, config_dict)
+        self.assertNotIn("signer", config_dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki/exchanges/limitless.md
+++ b/wiki/exchanges/limitless.md
@@ -639,6 +639,24 @@ Each market has a specific tick_size (minimum price increment). The tick_size is
 - [Base Exchange Class](../../dr_manhattan/base/exchange.py)
 - [Examples](../../examples/)
 
+## Signing Backends
+
+Limitless is the first venue with a pluggable signer (its EIP-712 signing lives
+fully in this repo, unlike the SDK-backed venues). Two backends:
+
+- **Local (default)**: `LIMITLESS_PRIVATE_KEY` - raw key in process memory via
+  eth-account, the historical behavior.
+- **Privy server wallet**: set `LIMITLESS_SIGNER=privy` plus `PRIVY_APP_ID`,
+  `PRIVY_APP_SECRET`, `PRIVY_WALLET_ID` (optional `PRIVY_WALLET_ADDRESS` to skip
+  one lookup). Signatures are produced by Privy's API
+  (`POST /v1/wallets/{id}/rpc`, methods `personal_sign` and
+  `eth_signTypedData_v4`); the raw key never enters this process. Free tier
+  covers 50k signatures/month. Programmatic use:
+  `Limitless({"signer": PrivySigner(...)})`.
+
+See [`dr_manhattan/base/signer.py`](../../dr_manhattan/base/signer.py) for the
+abstraction and why other venues are not wired yet.
+
 ## See Also
 
 - [Polymarket](./polymarket.md)


### PR DESCRIPTION
Adds a modular signer layer so Limitless can sign through a **Privy server wallet** instead of a raw in-process private key. The key never enters the process; Privy's free tier covers 50k signatures/month.

## What changed

- **`dr_manhattan/base/signer.py`** — a `Signer` ABC with two backends:
  - `LocalPrivateKeySigner`: the historical eth-account path (signature-identical to before).
  - `PrivySigner`: signs via `POST https://api.privy.io/v1/wallets/{id}/rpc` (HTTP basic auth + `privy-app-id` header; `personal_sign` and `eth_signTypedData_v4`; lazy address lookup). Verified against Privy's REST docs.
- **Limitless** now signs exclusively through `self._signer`. Config accepts either `private_key` (auto-wrapped, unchanged behavior) or an injected `signer` instance. Auth login and EIP-712 order signing both route through it.
- **Factory**: `LIMITLESS_SIGNER=privy` builds a `PrivySigner` from `PRIVY_APP_ID` / `PRIVY_APP_SECRET` / `PRIVY_WALLET_ID` (+ optional `PRIVY_WALLET_ADDRESS`); validation then requires those instead of a private key.
- **Exports**: `Signer`, `LocalPrivateKeySigner`, `PrivySigner` at package top level.
- **Docs**: `wiki/exchanges/limitless.md` backends section, `.env.example` entries.

## Scope

Only Limitless is wired — its EIP-712 signing lives fully in this repo. Polymarket, Opinion, and Predict.fun construct signatures inside their vendor SDKs (`py-clob-client`, `opinion-clob-sdk`, `predict-sdk`), so they still require raw keys until those SDKs expose a signer seam. This is documented in the module docstring.

## Verified

- `LocalPrivateKeySigner` is signature-identical to direct eth-account use for both `personal_sign` and EIP-712 (parity tests).
- Privy payload shape/auth/lazy-address, the Limitless seam via a stub signer, and factory backend validation — new tests in `tests/test_signers.py`.
- Full suite green: 366 passed, 11 skipped; ruff + mypy clean.
- Live keyless `Limitless().fetch_markets()` still works post-refactor.

**Reviewed and fixed (second commit):** a code review caught that uint256 message fields (notably `tokenId`, ~2^256) were being sent to Privy as bare JSON numbers, which its backend parses into float64 — losing precision and producing an invalid signature while login still succeeded. Fixed by string-encoding all integer leaves of `domain`/`message` before the request (the eth_signTypedData_v4 convention), with a serialization regression test asserting a 78-digit `tokenId` leaves the wire quoted.

**Not verified** (needs a Privy account): an end-to-end signed order through Privy against Limitless. Privy server wallets are EOAs, so `signatureType 0` holds.

Part of the key-management direction in `wiki/security/key-management.md` (phase 1). The self-hosted alternative is the `osterman` signing server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
